### PR TITLE
Tatt vekk "Skal ha med tavleoppføringer" og "Ta med prioriterte under…

### DIFF
--- a/src/main/resources/site/content-types/oppslagstavle/oppslagstavle.xml
+++ b/src/main/resources/site/content-types/oppslagstavle/oppslagstavle.xml
@@ -2,41 +2,10 @@
     <display-name>Oppslagstavle</display-name>
     <super-type>base:structured</super-type>
     <form>
-        <field-set name="meta">
-            <label>Oppslagstavle - informasjon</label>
-            <items>
-                <input type="TextLine" name="heading">
-                    <label>Tittel</label>
-                    <occurrences minimum="1" maximum="1"/>
-                </input>
-                <input type="TextLine" name="ingress">
-                    <label>Beskrivelse</label>
-                    <occurrences minimum="0" maximum="1" />
-                </input>
-                <input name="metaTags" type="Tag">
-                    <label>Meta-tagger for innhold. Er automatisert</label>
-                    <occurrences maximum="0" minimum="0"/>
-                </input>
         <field-set name="table">
             <label>Tavleoppføringer</label>
             <help-text>Tavleoppføringer hentes fra prioriterte underartikler og/eller fra valgt innhold</help-text>
             <items>
-                <input type="RadioButton" name="hasTableItems">
-                    <label>Skal ha tavleoppføringer?</label>
-                    <config>
-                        <option value="true">Ja</option>
-                        <option value="false">Nei</option>
-                    </config>
-
-                </input>
-                <input name="tableSelector" type="RadioButton">
-                    <label>Ta med prioriterte underartikler</label>
-                    <config>
-                        <option value="true">Ja</option>
-                        <option value="false">Nei</option>
-                    </config>
-
-                </input>
                 <input name="tableContents" type="ContentSelector">
                     <label>Velg innhold</label>
                     <allowPath>${site}/*</allowPath>
@@ -51,22 +20,6 @@
             <label>Nyheter</label>
             <help-text>Nyheter hentes fra prioriterte underartikler og/eller fra valgt innhold</help-text>
             <items>
-                <input name="hasNewsElements" type="RadioButton">
-                    <label>Ta med nyheter</label>
-                    <config>
-                        <option value="true">Ja</option>
-                        <option value="false">Nei</option>
-                    </config>
-
-                </input>
-                <input name="newsSelector" type="RadioButton">
-                    <label>Ta med prioriterte underartikler</label>
-                    <config>
-                        <option value="true">Ja</option>
-                        <option value="false">Nei</option>
-                    </config>
-
-                </input>
                 <input name="newsContents" type="ContentSelector">
                     <label>Velg innhold</label>
                     <allowPath>${site}/*</allowPath>
@@ -74,7 +27,6 @@
                 </input>
                 <input type="Long" name="nrNews">
                     <label>Hvor mange elementer i undermenyene er tillatt</label>
-
                 </input>
             </items>
         </field-set>
@@ -82,22 +34,6 @@
             <label>Nyttig å vite</label>
             <help-text>'Nyttig å vite' hentes fra prioriterte underartikler og/eller fra valgt innhold</help-text>
             <items>
-                <input name="hasNTKElements" type="RadioButton">
-                    <label>Ta med 'Nyttig å vite'</label>
-                    <config>
-                        <option value="true">Ja</option>
-                        <option value="false">Nei</option>
-                    </config>
-
-                </input>
-                <input name="ntkSelector" type="RadioButton">
-                    <label>Ta med prioriterte underartikler</label>
-                    <config>
-                        <option value="true">Ja</option>
-                        <option value="false">Nei</option>
-                    </config>
-
-                </input>
                 <input name="ntkContents" type="ContentSelector">
                     <label>Velg innhold</label>
                     <allowPath>${site}/*</allowPath>
@@ -105,7 +41,6 @@
                 </input>
                 <input type="Long" name="nrNTK">
                     <label>Hvor mange elementer i undermenyene er tillatt</label>
-
                 </input>
             </items>
         </field-set>
@@ -113,22 +48,6 @@
             <label>Snarveier</label>
             <help-text>Snarveier hentes fra prioriterte underartikler og/eller fra valgt innhold</help-text>
             <items>
-                <input name="hasSCElements" type="RadioButton">
-                    <label>Ta med snarveier</label>
-                    <config>
-                        <option value="true">Ja</option>
-                        <option value="false">Nei</option>
-                    </config>
-
-                </input>
-                <input name="scSelector" type="RadioButton">
-                    <label>Ta med prioriterte underartikler</label>
-                    <config>
-                        <option value="true">Ja</option>
-                        <option value="false">Nei</option>
-                    </config>
-
-                </input>
                 <input name="scContents" type="ContentSelector">
                     <label>Velg innhold</label>
                     <allowPath>${site}/*</allowPath>
@@ -136,13 +55,9 @@
                 </input>
                 <input type="Long" name="nrSC">
                     <label>Hvor mange elementer i undermenyene er tillatt</label>
-
                 </input>
             </items>
         </field-set>
-            </items>
-        </field-set>
-
     </form>
     <x-data mixin="menu-item"/>
 </content-type>


### PR DESCRIPTION
…artikler". Refaktorer ikke da koden snart vil bli endringer på nav.no. I tillegg er det alltid innhold under "Nyheter". "Snarveier" og "Nyttig å vite."