### PR TITLE
Feltet "innhold" under Relatert informasjon er ikke lenger obligatori…

### DIFF
--- a/src/main/resources/site/content-types/main-article/main-article.xml
+++ b/src/main/resources/site/content-types/main-article/main-article.xml
@@ -192,7 +192,7 @@
                     <label>Relatert informasjon</label>
                     <items>
                         <input type="MediaSelector" name="files">
-                            <occurrences maximum="0"  minimum="0"/>
+                            <occurrences minimum="0" maximum="0"/>
                             <label>Legg ved filer</label>
                             <help-text>Bruk som hovedregel kun pdf-filer. Filer skal ha beskrivende navn da disse vises.</help-text>
                             <config>
@@ -202,7 +202,7 @@
                         <input name="link" type="ContentSelector">
                             <label>Innhold</label>
                             <custom-text>contentdata/links</custom-text>
-                            <occurrences maximum="0" minimum="1"/>
+                            <occurrences maximum="0" minimum="0"/>
                             <config>
                                 <allow-content-type>no.nav.navno:Fil</allow-content-type>
                                 <allow-content-type>no.nav.navno:Ekstern_lenke</allow-content-type>


### PR DESCRIPTION
…sk. Årsak: Hvis man skal kun legge til filer, må man ikke legge til innhold i tillegg.