### PR TITLE
added meta description field to content studio

### DIFF
--- a/src/main/resources/site/content-types/main-article/main-article.xml
+++ b/src/main/resources/site/content-types/main-article/main-article.xml
@@ -14,6 +14,7 @@
                     <help-text>Ingressen bør være maks. 240 tegn.</help-text>
                     <occurrences maximum="1" minimum="1"/>
                 </input>
+                <mixin name="meta-description"/>
                 <input type="HtmlArea" name="text">
                     <label>Brødtekst</label>
                     <help-text>Artikler/nyheter skal som hovedregel være på maks 2 500 tegn.</help-text>

--- a/src/main/resources/site/content-types/page-list/page-list.xml
+++ b/src/main/resources/site/content-types/page-list/page-list.xml
@@ -19,6 +19,7 @@
             <label>Ingress</label>
             <occurrences minimum="0" maximum="1"/>
         </input>
+        <mixin name="meta-description"/>
         <input type="CheckBox" name="hideSectionContentsDate">
             <label>Skjul dato på artiklene i artikkellisten</label>
             <default>unchecked</default>

--- a/src/main/resources/site/content-types/section-page/section-page.xml
+++ b/src/main/resources/site/content-types/section-page/section-page.xml
@@ -2,6 +2,12 @@
     <display-name>Oppslagstavle</display-name>
     <super-type>base:unstructured</super-type>
     <form>
+        <field-set name="beskrivelse">
+            <label>Beskrivelse</label>
+            <items>
+            <mixin name="meta-description"/>
+            </items>
+        </field-set>
         <field-set name="table">
             <label>Tavleoppføringer</label>
             <help-text>Tavleoppføringer hentes fra prioriterte underartikler og/eller fra valgt innhold</help-text>

--- a/src/main/resources/site/mixins/meta-description/meta-description.xml
+++ b/src/main/resources/site/mixins/meta-description/meta-description.xml
@@ -1,0 +1,9 @@
+<mixin>
+    <display-name>Meta description</display-name>
+    <form>
+        <input name="metaDescription" type="TextLine">
+            <label>Beskrive siden, innhold og formål for resultat i søkemotorer.</label>
+            <help-text>Meta description brukes av søkemotorer til å beskrive en side i søkeresultater.</help-text>
+        </input>
+    </form>
+</mixin>

--- a/src/main/resources/site/pages/main-page/main-page.es6
+++ b/src/main/resources/site/pages/main-page/main-page.es6
@@ -30,6 +30,7 @@ function handleGet (req) {
         title: content.displayName + ' - www.nav.no',
         mainRegion: mainRegion,
         footerRegion: footer,
+        description: content.data.metaDescription
     };
     const assets = [
         '<link rel="apple-touch-icon" href="' + libs.portal.assetUrl({

--- a/src/main/resources/site/pages/main-page/main-page.html
+++ b/src/main/resources/site/pages/main-page/main-page.html
@@ -5,6 +5,7 @@
         <title>[[${title}]]</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta data-th-if="${description}" name="description" data-th-content="${description}" />
     </head>
 
     <body itemscope="" itemtype="http://schema.org/Webpage" class="device-class-desktop" data-portal-component-type="page">


### PR DESCRIPTION
Added meta description to content studio in CMS

The `meta description` tag on webpages is used by search engines to describe a page in search results. Using it will increase visibility of our webpages, help users find the right content and help search engines understand the content and index it for related search queries. See Mozilla Developer Network for more info.