### PR TITLE
Iv 561 kibana

### DIFF
--- a/logback.xml
+++ b/logback.xml
@@ -21,9 +21,6 @@
     </appender>
 
     <appender name="SYSLOG" class="ch.qos.logback.classic.net.SyslogAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>INFO</level>
-        </filter>
         <syslogHost>localhost</syslogHost>
         <facility>LOCAL1</facility>
         <suffixPattern>${MAIN_APPLICATION} %mdc %logger{30} %m %n%rEx</suffixPattern>


### PR DESCRIPTION
Kopiert ut logback-config fra /data/home/config/, og lagt til syslog. Dette er nødvendig for at Kibana skal kunne plukke opp logginnslagene.

Den erstatter eksisterende logback-config, og må manuelt legges ut på hver node vi vil at skal logge til Kibana.