### PR TITLE
fiks regex for å matche + symbolet

### DIFF
--- a/src/main/resources/site/error/error.es6
+++ b/src/main/resources/site/error/error.es6
@@ -66,7 +66,7 @@ exports.handle404 = function (req) {
                 path.toLowerCase()
                     .replace('/www.nav.no/', 'https://www.nav.no/')
                     .replace(/ - /g, '-')
-                    .replace(/ + /g, '-')
+                    .replace(/\+/g, '-')
                     .replace(/ /g, '-')
                     .replace(/ø/g, 'o')
                     .replace(/æ/g, 'ae')


### PR DESCRIPTION
Escape "+"-symbolet i regex

Min forrige PR inneholdt en feil fordi + er en operator i regulæruttrykk. Man må escape symbolet for å matche på det i en string. 