### PR TITLE
Fix på at bilde/ikon ikke lastes inn ved deling på sosiale medier 

### DIFF
--- a/src/main/resources/site/pages/main-page/main-page.es6
+++ b/src/main/resources/site/pages/main-page/main-page.es6
@@ -28,12 +28,12 @@ function handleGet (req) {
             '<meta property="og:site_name" content="NAV" />',
             '<meta property="og:url" content="' + url + '" />',
             '<meta property="og:description" content="' + description + '" />',
-            '<meta property="og:image" content="' + imageUrl + '" />',
+            '<meta property="og:image" content="https://nav.no' + imageUrl + '" />',
             '<meta name="twitter:card" content="summary_large_image" />',
             '<meta name="twitter:domain" content="nav.no" />',
             '<meta name="twitter:title" content="' + title + '" />',
             '<meta name="twitter:description" content="' + description + '" />',
-            '<meta name="twitter:image:src" content="' + imageUrl + '" />'
+            '<meta name="twitter:image:src" content="https://nav.no' + imageUrl + '" />'
         ];
         const regions = content.page.regions;
         const model = {


### PR DESCRIPTION
(twitter). Dette er kun en quick-fix.

Oppretter en ny Jira-sak for litt større endringer. Ref. kommentar fra Tov-Are Jacobsen:

Det er gunstig hvis det er rom for en gjennomgang av denne saken fremfor en ren feilfiks. Standardene har utviklet seg noe siden 2013 og Twitter leser nå Open Graph (som vi har inne for facebook), samtidig har gevinstene med en liten blokk metadata med json+ld økt. I dette tilfellet  (se vedlagt skjermbilde) validerer metadata uten at det funger, men vi har litt legacy som ikke er en del av noen gjeldende standard.

 