### PR TITLE
Fikset styling på "Nyttig å vite", "Nyheter" og "Snarveier".

### DIFF
--- a/src/main/resources/site/parts/section-page/section-page.es6
+++ b/src/main/resources/site/parts/section-page/section-page.es6
@@ -12,7 +12,6 @@ exports.get = function (req) {
     return libs.cache.getPaths(req.rawPath, 'section-page', req.branch, () => {
         const content = libs.portal.getContent();
         const lang = libs.lang.parseBundle(content.language).oppslagstavle;
-        let col = 'col-md-';
         const tableList = getTableElements(content, 'tableContents');
         const table = (tableList && tableList.length > 0
             ? tableList.slice(0, content.data.nrTableEntries)
@@ -46,10 +45,6 @@ exports.get = function (req) {
                 : null),
         };
 
-        let antCol = !!niceToKnow.data + !!news.data + !!shortcuts.data;
-        if (antCol === 0) { antCol = 1; }
-        col += 12 / antCol;
-
         let localSectionPage = false;
         const pathParts = content._path.split('/');
         if (pathParts[pathParts.length - 2] === 'lokalt') {
@@ -62,7 +57,6 @@ exports.get = function (req) {
             news,
             moreNewsUrl: content.data.moreNewsUrl,
             shortcuts,
-            col,
             localSectionPage,
         };
         return {

--- a/src/main/resources/site/parts/section-page/section-page.html
+++ b/src/main/resources/site/parts/section-page/section-page.html
@@ -15,7 +15,7 @@
 </section>
 
 <section class="row inner-row linklists-container">
-    <div data-th-if="${niceToKnow.data}" class="col-sm-12" data-th-classappend="${col}" >
+    <div data-th-if="${niceToKnow.data}" class="col-sm-12 col-md-4" >
         <h2 class="h4 decorated">
             [[${niceToKnow.sectionName}]]
         </h2>
@@ -27,7 +27,7 @@
             </li>
         </ul>
     </div>
-    <div data-th-if="${news.data}" class="col-sm-12" data-th-classappend="${col}">
+    <div data-th-if="${news.data}" class="col-sm-12 col-md-4">
         <h2 class="h4 decorated">
             [[${news.sectionName}]]
         </h2>
@@ -45,7 +45,7 @@
             </li>
         </ul>
     </div>
-    <div data-th-if="${shortcuts.data}" class="col-sm-12" data-th-classappend="${col}">
+    <div data-th-if="${shortcuts.data}" class="col-sm-12 col-md-4">
         <h2 class="h4 decorated">
             [[${shortcuts.sectionName}]]
         </h2>


### PR DESCRIPTION
Kolonnene blir alltid midtstilt, og strekkes aldri ut over hele siden når det er færre en tre kolonner.