### PR TITLE
IV-846-Feil-styling-på-filer-under-Relatert-innhold

### DIFF
--- a/src/main/resources/assets/styles/navno.css
+++ b/src/main/resources/assets/styles/navno.css
@@ -4993,6 +4993,7 @@ a.knapp {
 .related-content.accordion {
     border: none;
 }
+
 .accordion .accordion-item .h3 {
     font-size: 1.0675rem;
     margin: 0;
@@ -5023,6 +5024,11 @@ a.knapp {
 
 .accordion-panel ul li {
     margin-bottom: 20px
+}
+
+.accordion-panel ul li a {
+    overflow-wrap: break-word;
+    word-break: break-word
 }
 
 .accordion-panel ul li:last-child {


### PR DESCRIPTION
Lange filnavn som mangler mellomrom eller bindestrek brekkes ikke under Relatert innhold.