### PR TITLE
IV-857-feil-styling-pa tabeller

### DIFF
--- a/src/main/resources/assets/styles/navno.css
+++ b/src/main/resources/assets/styles/navno.css
@@ -3570,7 +3570,7 @@ a.knapp {
 
 .article-body table {
     width: 100%;
-    line-height: 1.15em
+    line-height: 1.15em;
 }
 
 .article-body table tr:first-child th, .article-body table tr:first-child td {
@@ -3595,6 +3595,9 @@ a.knapp {
     line-height: 1.375rem
 }
 
+.article-body table tr:last-child {
+    border-bottom: 1px solid rgba(0, 0, 0, 0.55);
+}
 
 .article-body table tr:first-child th strong, .article-body table tr:first-child td strong {
     font-size: 1.1em;
@@ -3603,7 +3606,6 @@ a.knapp {
 }
 
 .article-body table th, .article-body table td {
-    padding-top: 0;
     padding: 10px;
     vertical-align: top;
     font-size: .875rem


### PR DESCRIPTION
Har endret css slik at tabeller i brødtekst skal ligne mest mulig  på "tabell--stripet" i designsystemet. (Gjelder ikke store tabeller). 

Har tatt skjermdump av tabell i designsystemet vs. hvordan en tabell vil se ut nå etter endring av css.