### PR TITLE
IV-854-Filer-skal-også-kunne-lastes-opp-med-annet-innhold

### DIFF
--- a/src/main/resources/site/content-types/main-article/main-article.xml
+++ b/src/main/resources/site/content-types/main-article/main-article.xml
@@ -98,6 +98,7 @@
                                         <allow-content-type>${app}:external-link</allow-content-type>
                                         <allow-content-type>${app}:internal-link</allow-content-type>
                                         <allow-content-type>${app}:section-page</allow-content-type>
+                                        <allow-content-type>media:*</allow-content-type>
                                         <showStatus>true</showStatus>
                                     </config>
                                 </input>


### PR DESCRIPTION
Det er ønskelig at filer også kan legges under Relatert informasjon via ContentSelector. Da kan filer legges sammen med annet innhold, og ikke alltid nederst slik det er i dag.