### PR TITLE
IV-915: release the lock

### DIFF
--- a/src/main/resources/lib/siteCache/invalidator.es6
+++ b/src/main/resources/lib/siteCache/invalidator.es6
@@ -5,6 +5,7 @@ const libs = {
     node: require('/lib/xp/node'),
     repo: require('/lib/xp/repo'),
     event: require('/lib/xp/event'),
+    cluster: require('/lib/xp/cluster'),
 };
 const masterRepo = libs.node.connect({
     repoId: 'com.enonic.cms.default',
@@ -187,13 +188,18 @@ function runTask(applicationIsRunning) {
             try {
                 const state = getState();
 
-                // There is one conditions which must be upheld for the cache invalidator to run
+                // There is two conditions which must be upheld for the cache invalidator to run
                 // --
                 // 1. No other task is currently doing the invalidation
+                // 2. The node has to be master
                 // --
                 // if not the task must sleep for TIME_BETWEEN_CHECKS
 
                 if (state.isRunning) {
+                    libs.task.sleep(TIME_BETWEEN_CHECKS);
+                    return;
+                }
+                if (!libs.cluster.isMaster()) {
                     libs.task.sleep(TIME_BETWEEN_CHECKS);
                     return;
                 }

--- a/src/main/resources/main.es6
+++ b/src/main/resources/main.es6
@@ -20,35 +20,36 @@ textCleaner.activateEventListener();
 if (clusterLib.isMaster()) {
     // make sure the lock is released on startup
     invalidator.releaseInvalidatorLock();
+}
 
-    let currentTaskId = invalidator.start(appIsRunning);
-    taskIds.push(currentTaskId);
+let currentTaskId = invalidator.start(appIsRunning);
+taskIds.push(currentTaskId);
 
-    // keep the process of handling expired content in the cache alive.
-    eventLib.listener({
-        type: 'task.*',
-        localOnly: true,
-        callback: event => {
-            // need to listen to all task events and filter on finished and failed for resurrection
-            if (['task.finished', 'task.failed'].indexOf(event.type) === -1) {
+// keep the process of handling expired content in the cache alive.
+eventLib.listener({
+    type: 'task.*',
+    localOnly: true,
+    callback: event => {
+        // need to listen to all task events and filter on finished and failed for resurrection
+        if (['task.finished', 'task.failed'].indexOf(event.type) === -1) {
+            return false;
+        }
+        if (event.data.description === invalidator.taskDescription) {
+            // if the task which have finished is not in current state, ignore it.
+            if (taskIds.indexOf(event.data.id) === -1) {
                 return false;
             }
-            if (event.data.description === invalidator.taskDescription) {
-                // if the task which have finished is not in current state, ignore it.
-                if (taskIds.indexOf(event.data.id) === -1) {
-                    return false;
-                }
-                // update state and spawn of a new task
-                taskIds = taskIds.filter(task => task !== event.data.id);
-                currentTaskId = invalidator.runTask(appIsRunning);
-                if (currentTaskId) {
-                    taskIds.push(currentTaskId);
-                }
+            // update state and spawn of a new task
+            taskIds = taskIds.filter(task => task !== event.data.id);
+            currentTaskId = invalidator.runTask(appIsRunning);
+            if (currentTaskId) {
+                taskIds.push(currentTaskId);
             }
-            return true;
-        },
-    });
-}
+        }
+        return true;
+    },
+});
+
 log.info('Finished running main');
 
 __.disposer(function() {


### PR DESCRIPTION
We have gotten a state where the lock for the invalidator is set to true. So none of the new tasks are able to get the task up and running which should invalidate the cache for prepublished events.

This fix should handle this, also we've made improvements so not all the nodes are running the task to prevent race conditions.