### PR TITLE
Iv 927 font

### DIFF
--- a/src/main/resources/assets/styles/navno.css
+++ b/src/main/resources/assets/styles/navno.css
@@ -2097,7 +2097,6 @@ button.toggle-search.m-open span {
 
 .pagewrapper {
     height: auto;
-    min-height: 100%;
     margin-bottom: -200px;
     padding-bottom: 200px
 }


### PR DESCRIPTION
1. Justerer fontstørrelsen opp på vanlig tekst etter at Source Sans Pro nå er aktiv (ikke fallback Arial)
2. Fjernet min-height på pagewrapper så ikke footer kommer langt ned på korte sider
3. Laget placeholder for header slik at ikke siden dyttes ned hvis dekoratøren lastes etter siden