### PR TITLE
Bypassing the query sort to solve sorting bug

### DIFF
--- a/src/main/resources/site/parts/link-lists/link-lists.es6
+++ b/src/main/resources/site/parts/link-lists/link-lists.es6
@@ -78,7 +78,7 @@ exports.get = (req) => {
         };
 
         // news
-        const newsList = getContentLists(content, 'newsContents', content.data.nrNews, true);
+        const newsList = getContentLists(content, 'newsContents', 999, false);
         const news = {
             sectionName: langBundle.news,
             data:


### PR DESCRIPTION
For now we just need to bypass the sorting from the query to get the proper sorting while we handle the actual issue.