### PR TITLE
507-Fjernet-krav-for-å-legge-inn-ikoner-med alt-tekst.

### DIFF
--- a/src/main/resources/site/mixins/link-panels/link-panels.xml
+++ b/src/main/resources/site/mixins/link-panels/link-panels.xml
@@ -49,17 +49,6 @@
                                 </input>
                             </items>
                         </item-set>
-                        <input name="icon" type="ImageSelector">
-                            <label>Velg ikon</label>
-                            <occurrences minimum="0" maximum="1"/>
-                        </input>
-                        <input name="altText" type="TextLine">
-                            <label>Alternativ tekst til ikonet</label>
-                            <help-text>
-                                Tekst som vises eller leses opp når bildet ikke vises for brukeren
-                            </help-text>
-                            <occurrences minimum="1" maximum="1"/>
-                        </input>
                     </items>
                     <occurrences maximum="0" minimum="0"/>
                 </item-set>

--- a/src/main/resources/site/parts/link-panels/link-panels.es6
+++ b/src/main/resources/site/parts/link-panels/link-panels.es6
@@ -21,12 +21,6 @@ exports.get = (req) => {
                     title: value.title,
                     ingress: value.ingress,
                     url: libs.navUtils.getUrl(value.url),
-                    altText: value.altText || '',
-                    icon: value.icon
-                        ? libs.portal.attachmentUrl({
-                              id: value.icon,
-                          })
-                        : null,
                     className: value.spanning ? 'heldekkende' : '',
                 })),
             };

--- a/src/main/resources/site/parts/link-panels/link-panels.html
+++ b/src/main/resources/site/parts/link-panels/link-panels.html
@@ -9,9 +9,6 @@
            data-ga="link-panel"
            data-th-href="${item.url}"
         >
-            <div data-th-if="${item.icon}" class="icon">
-                <img data-th-src="${item.icon}" data-th-attr="alt=${item.altText}" class="icon-size" />
-            </div>
             <div class="tekst">
                 <h3 class="typo-systemtittel lenkepanel__heading">
                     [[${item.title}]]


### PR DESCRIPTION
Lenkepaneler skal ikke ha ikoner. Fjernet derfor muligheten for å legge inn ikoner og alt-tekst. 