### PR TITLE
Stramme inn valg i HTML-felter i brødtekst og faktaboks i main-article

### DIFF
--- a/src/main/resources/site/content-types/main-article/main-article.xml
+++ b/src/main/resources/site/content-types/main-article/main-article.xml
@@ -16,7 +16,9 @@
                     <help-text>Artikler/nyheter skal som hovedregel være på maks 2 500 tegn.</help-text>
                     <occurrences minimum="1" maximum="1"/>
                     <config>
-                        <include>Undo | Redo</include>
+                        <include>Undo Redo</include>
+                        <exclude>JustifyBlock Underline</exclude>
+                        <allowHeadings>h3 normal</allowHeadings>
                     </config>
                 </input>
                 <input type="RadioButton" name="contentType">
@@ -48,6 +50,11 @@
                     <label>Faktaboksen vises under brødteksten</label>
                     <help-text>Bruk maks 500 tegn.</help-text>
                     <occurrences minimum="0" maximum="1"/>
+                    <config>
+                        <include>Undo Redo</include>
+                        <exclude>JustifyBlock Underline</exclude>
+                        <allowHeadings>h3 normal</allowHeadings>
+                    </config>
                 </input>
             </items>
         </field-set>


### PR DESCRIPTION
Gjelder brødtekst og faktaboks i main-article:

Fjernet muligheten for blokkjuster, dvs. at venstre- og høyremargen
kommer på linje.

Fjernet muligheten for underline.
Fjernet h1, h2, h4, h5, h6 i stiler

Kursiv skal beholdes.