### PR TITLE
Issue 727 stramme inn hvilke inneholdstyper som er lov ha i nyhetslister

### DIFF
--- a/src/main/resources/site/content-types/content-list/content-list.xml
+++ b/src/main/resources/site/content-types/content-list/content-list.xml
@@ -13,6 +13,9 @@
                     <occurrences maximum="0" minimum="0"/>
                     <config>
                         <showStatus>true</showStatus>
+                        <allowContentType>${app}:main-article</allowContentType>
+                        <allowContentType>${app}:internal-link</allowContentType>
+                        <allowContentType>${app}:external-link</allowContentType>
                     </config>
                 </input>
             </items>


### PR DESCRIPTION
Strammet inn hva som kan legges til i innholdslister.

Etter avtale med Janne Bye skal det kunne legges til main-article, ekstern- og intern lenke.