### PR TITLE
Rekkefølgen under nyhetslistene skal sorteres etter publish first.

### DIFF
--- a/src/main/resources/lib/headless/sort.es6
+++ b/src/main/resources/lib/headless/sort.es6
@@ -3,9 +3,8 @@ const getLastUpdatedUnixTime = (content) =>
 
 const getPublishedUnixTime = (content) =>
     new Date(
-        content.publish?.from?.split('.')[0] ||
-            content.publish?.first?.split('.')[0] ||
-            content.createdTime?.split('.')[0]
+        content.publish?.first?.split('.')[0] ||
+             content.createdTime?.split('.')[0]
     ).getTime();
 
 const sortByLastModifiedDesc = (a, b) => getLastUpdatedUnixTime(b) - getLastUpdatedUnixTime(a);


### PR DESCRIPTION
Reversering av denne: https://github.com/navikt/nav-enonicxp/pull/783