### PR TITLE
Fikser GraphQL null-error ved redirect til internal-link uten target

### DIFF
--- a/src/main/resources/lib/headless/guillotine/queries/sitecontent.es6
+++ b/src/main/resources/lib/headless/guillotine/queries/sitecontent.es6
@@ -130,15 +130,20 @@ const getRedirectContent = (idOrPath, branch) => {
         }
 
         if (shortUrlTarget.type === 'no.nav.navno:internal-link') {
-            const target = getContent(shortUrlTarget.data?.target);
+            const target = shortUrlTarget.data?.target;
             if (!target) {
+                return null;
+            }
+
+            const targetContent = getContent(target);
+            if (!targetContent) {
                 return null;
             }
 
             return {
                 ...shortUrlTarget,
                 __typename: 'no_nav_navno_InternalLink',
-                data: { target: { _path: target._path } },
+                data: { target: { _path: targetContent._path } },
             };
         }
 


### PR DESCRIPTION
Har ingen funksjonelle konsekvenser (skal uansett returnere null ved tom internal-link), men fjerner litt log-støy