### PR TITLE
Rekkefølgen under nyhetslistene skal sorteres etter publish first.

### DIFF
--- a/src/main/resources/lib/headless/sort.es6
+++ b/src/main/resources/lib/headless/sort.es6
@@ -3,8 +3,7 @@ const getLastUpdatedUnixTime = (content) =>
 
 const getPublishedUnixTime = (content) =>
     new Date(
-        content.publish?.from?.split('.')[0] ||
-            content.publish?.first?.split('.')[0] ||
+        content.publish?.first?.split('.')[0] ||
             content.createdTime?.split('.')[0]
     ).getTime();
 


### PR DESCRIPTION
Endring er allerede gjort i ContentList i frontenden.