### PR TITLE
Nye parts/mixins ++

### DIFF
--- a/src/main/resources/lib/headless/guillotine/guillotine-schema.es6
+++ b/src/main/resources/lib/headless/guillotine/guillotine-schema.es6
@@ -14,6 +14,7 @@ const { menuListDataCallback } = require('./schema-creation-callbacks/menu-list-
 const contentListCallback = require('./schema-creation-callbacks/content-list-callback');
 const largeTableCallback = require('./schema-creation-callbacks/large-table');
 const { contentListDataCallback } = require('./schema-creation-callbacks/content-list-data');
+const { htmlAreaPartConfigCallback } = require('./schema-creation-callbacks/html-area-part-config');
 const {
     mainArticleDataCallback,
     mainArticleCallback,
@@ -42,6 +43,7 @@ const schemaContextOptions = {
         no_nav_navno_PageList_InnholdIHYremenyen: menuListDataCallback,
         PartConfigDynamicNewsList_InnholdslisteForNyheter: contentListCallback('publish.first'),
         PartConfigDynamicLinkList_HentLenkerFraInnholdsliste: contentListCallback(),
+        PartConfigHtmlArea: htmlAreaPartConfigCallback,
     },
 };
 

--- a/src/main/resources/lib/headless/guillotine/queries/fragments/_components.es6
+++ b/src/main/resources/lib/headless/guillotine/queries/fragments/_components.es6
@@ -1,16 +1,15 @@
-const { linkInternalMixinFragment } = require('./_mixins');
-const { linkExternalMixinFragment } = require('./_mixins');
-const { linkWithIngressMixinFragment } = require('./_mixins');
-const contentListMixinFragment = require('./dangerous-mixins/content-list-mixin');
+const { linkWithIngressMixinFragment, linkSelectableMixin } = require('./_mixins');
 const { imageFragment } = require('./media');
+const contentListMixinFragment = require('./dangerous-mixins/content-list-mixin');
+const { headerCommonMixin } = require('/lib/headless/guillotine/queries/fragments/_mixins');
 
 const partsFragment = `
     config {
         no_nav_navno {
             dynamic_header {
                 title
-                ingress
-                titleTypo
+                anchorId
+                ${headerCommonMixin}
             }
             dynamic_link_panel {
                 ${linkWithIngressMixinFragment}
@@ -47,13 +46,7 @@ const partsFragment = `
                     }
                     linkList {
                         links {
-                            _selected
-                            external {
-                                ${linkExternalMixinFragment}
-                            }
-                            internal {
-                                ${linkInternalMixinFragment}
-                            }
+                            ${linkSelectableMixin}
                         }
                     }
                 }
@@ -66,6 +59,20 @@ const partsFragment = `
                 moreNews {
                     url
                     text
+                }
+            }
+            html_area {
+                html(processHtml:{type: server})
+            }
+            page_header {
+                title
+            }
+            button {
+                icon {
+                    ${imageFragment}
+                }
+                link {
+                    ${linkSelectableMixin}
                 }
             }
         }
@@ -90,7 +97,7 @@ const componentsContent = `
     }
     image {
         image {
-            imageUrl(scale:"$scale", type:server)
+            imageUrl(scale: "$scale", type: server)
         }
     }
 `;

--- a/src/main/resources/lib/headless/guillotine/queries/fragments/_mixins.es6
+++ b/src/main/resources/lib/headless/guillotine/queries/fragments/_mixins.es6
@@ -37,15 +37,29 @@ const linkExternalMixinFragment = `
     text
 `;
 
+const linkSelectableMixin = `
+    _selected
+    external {
+        ${linkExternalMixinFragment}
+    }
+    internal {
+        ${linkInternalMixinFragment}
+    }
+`;
+
 const linkWithIngressMixinFragment = `
     ingress
     link {
+        ${linkSelectableMixin}
+    }
+`;
+
+const headerCommonMixin = `
+    justify
+    typo {
         _selected
-        internal {
-            ${linkInternalMixinFragment}
-        }
-        external {
-            ${linkExternalMixinFragment}
+        custom {
+            typo
         }
     }
 `;
@@ -56,4 +70,6 @@ module.exports = {
     linkInternalMixinFragment,
     linkExternalMixinFragment,
     linkWithIngressMixinFragment,
+    linkSelectableMixin,
+    headerCommonMixin,
 };

--- a/src/main/resources/lib/headless/guillotine/schema-creation-callbacks/html-area-part-config.es6
+++ b/src/main/resources/lib/headless/guillotine/schema-creation-callbacks/html-area-part-config.es6
@@ -1,0 +1,10 @@
+const { htmlCleanUp } = require('./common/html-cleanup');
+
+const htmlAreaPartConfigCallback = (context, params) => {
+    params.fields.html.resolve = (env) => {
+        const html = env.source?.html;
+        return html ? htmlCleanUp(html) : null;
+    };
+};
+
+module.exports = { htmlAreaPartConfigCallback };

--- a/src/main/resources/site/mixins/header-common/header-common.xml
+++ b/src/main/resources/site/mixins/header-common/header-common.xml
@@ -1,0 +1,42 @@
+<mixin>
+    <form>
+        <input name="justify" type="RadioButton">
+            <label>Justering</label>
+            <occurrences minimum="1" maximum="1"/>
+            <config>
+                <option value="left">Venstre</option>
+                <option value="center">Sentrert</option>
+                <option value="right">Høyre</option>
+            </config>
+            <default>center</default>
+        </input>
+        <option-set name="typo">
+            <label>Typografi</label>
+            <occurrences minimum="1" maximum="1"/>
+            <options minimum="1" maximum="1">
+                <option name="default">
+                    <label>Standard</label>
+                    <help-text>Standard typografi-stil for headeren (skal som hovedregel benyttes)</help-text>
+                    <default>true</default>
+                </option>
+                <option name="custom">
+                    <label>Tilpasset</label>
+                    <help-text>Egenvalgt typografi-stil</help-text>
+                    <items>
+                        <input name="typo" type="RadioButton">
+                            <label>Velg typografi-stil</label>
+                            <occurrences minimum="1" maximum="1"/>
+                            <config>
+                                <option value="sidetittel">Sidetittel</option>
+                                <option value="innholdstittel">Innholdstittel</option>
+                                <option value="systemtittel">Systemtittel</option>
+                                <option value="undertittel">Undertittel</option>
+                                <option value="element">Element (normal bold)</option>
+                            </config>
+                        </input>
+                    </items>
+                </option>
+            </options>
+        </option-set>
+    </form>
+</mixin>

--- a/src/main/resources/site/mixins/link-with-ingress/link-with-ingress.xml
+++ b/src/main/resources/site/mixins/link-with-ingress/link-with-ingress.xml
@@ -1,26 +1,6 @@
 <mixin>
     <form>
-        <option-set name="link">
-            <label>Lenke</label>
-            <occurrences minimum="1" maximum="1"/>
-            <options minimum="1" maximum="1">
-                <option name="internal">
-                    <label>Intern lenke</label>
-                    <help-text>Lenke til internt innhold</help-text>
-                    <default>true</default>
-                    <items>
-                        <mixin name="link-internal" />
-                    </items>
-                </option>
-                <option name="external">
-                    <label>Ekstern lenke</label>
-                    <help-text>Lenke til innhold utenfor CMS'et</help-text>
-                    <items>
-                        <mixin name="link-external" />
-                    </items>
-                </option>
-            </options>
-        </option-set>
+        <mixin name="link"/>
         <input name="ingress" type="TextArea">
             <label>Ingress</label>
         </input>

--- a/src/main/resources/site/mixins/link/link.xml
+++ b/src/main/resources/site/mixins/link/link.xml
@@ -1,0 +1,25 @@
+<mixin>
+    <form>
+        <option-set name="link">
+            <occurrences minimum="1" maximum="1"/>
+            <expanded>true</expanded>
+            <options minimum="1" maximum="1">
+                <option name="internal">
+                    <label>Intern lenke</label>
+                    <help-text>Lenke til internt innhold</help-text>
+                    <default>true</default>
+                    <items>
+                        <mixin name="link-internal" />
+                    </items>
+                </option>
+                <option name="external">
+                    <label>Ekstern lenke</label>
+                    <help-text>Lenke til innhold utenfor CMS'et</help-text>
+                    <items>
+                        <mixin name="link-external" />
+                    </items>
+                </option>
+            </options>
+        </option-set>
+    </form>
+</mixin>

--- a/src/main/resources/site/mixins/page-header/page-header.xml
+++ b/src/main/resources/site/mixins/page-header/page-header.xml
@@ -1,0 +1,9 @@
+<mixin>
+    <form>
+        <input type="TextLine" name="title">
+            <label>H1 header for siden</label>
+            <occurrences minimum="1" maximum="1"/>
+            <default>Side-tittel</default>
+        </input>
+    </form>
+</mixin>

--- a/src/main/resources/site/parts/button/button.es6
+++ b/src/main/resources/site/parts/button/button.es6
@@ -1,0 +1,3 @@
+const controller = require('/lib/headless/controllers/component-preview-controller');
+
+exports.get = controller;

--- a/src/main/resources/site/parts/button/button.xml
+++ b/src/main/resources/site/parts/button/button.xml
@@ -1,0 +1,38 @@
+<part xmlns="urn:enonic:xp:model:1.0">
+    <display-name>_Knapp</display-name>
+    <form>
+        <mixin name="link"/>
+        <input name="type" type="RadioButton">
+            <label>Type</label>
+            <occurrences minimum="1" maximum="1" />
+            <config>
+                <option value="standard">Normal</option>
+                <option value="hoved">Hoved</option>
+                <option value="fare">Fare</option>
+                <option value="flat">Flat</option>
+            </config>
+            <default>standard</default>
+        </input>
+        <input name="size" type="RadioButton">
+            <label>Størrelse</label>
+            <occurrences minimum="1" maximum="1" />
+            <config>
+                <option value="normal">Normal</option>
+                <option value="kompakt">Kompakt</option>
+                <option value="mini">Mini</option>
+            </config>
+            <default>normal</default>
+        </input>
+        <input name="fullwidth" type="CheckBox">
+            <label>Full bredde</label>
+        </input>
+        <input name="icon" type="ImageSelector">
+            <label>Ikon (valgfritt)</label>
+            <config>
+                <allowPath>${site}/nav.no-ressurser/bilder/svg-ikoner</allowPath>
+                <allowPath>${site}/nav.no-ressurser/bilder/ikoner</allowPath>
+                <allowPath>./*</allowPath>
+            </config>
+        </input>
+    </form>
+</part>

--- a/src/main/resources/site/parts/dynamic-alert/dynamic-alert.xml
+++ b/src/main/resources/site/parts/dynamic-alert/dynamic-alert.xml
@@ -1,5 +1,5 @@
 <part xmlns="urn:enonic:xp:model:1.0">
-    <display-name>Dynamisk alertstripe</display-name>
+    <display-name>_Varselstripe</display-name>
     <description>https://design.nav.no/components/alertstripe</description>
     <form>
         <input type="ComboBox" name="type">

--- a/src/main/resources/site/parts/dynamic-header/dynamic-header.xml
+++ b/src/main/resources/site/parts/dynamic-header/dynamic-header.xml
@@ -1,38 +1,36 @@
 <part xmlns="urn:enonic:xp:model:1.0">
-    <display-name>Tittel</display-name>
-    <description>Med valgfri ingress</description>
+    <display-name>_Header</display-name>
+    <description>H2-H6 header</description>
     <form>
         <input name="title" type="TextLine">
             <label>Tittel</label>
             <occurrences minimum="1" maximum="1" />
             <default>Tittel</default>
         </input>
-        <input name="titleTypo" type="RadioButton">
-            <label>Typografi</label>
-            <occurrences minimum="1" maximum="1" />
+        <input name="anchorId" type="TextLine">
+            <label>Anker-id</label>
+            <help-text>
+                Sett et anker-id for å kunne lenke til denne delen av siden
+                Eks: https://www.nav.no/no/min-side#mitt-anker
+                Dette feltet benyttes også av komponenten for intern-navigasjon på siden
+            </help-text>
+            <occurrences minimum="0" maximum="1"/>
             <config>
-                <option value="sidetittel">Sidetittel</option>
-                <option value="innholdstittel">Innholdstittel</option>
-                <option value="systemtittel">Systemtittel</option>
-                <option value="undertittel">Undertittel</option>
+                <regexp>^[0-9a-zA-Z-_]*$</regexp>
             </config>
-            <default>innholdstittel</default>
         </input>
         <input name="titleTag" type="RadioButton">
             <label>Heading tag</label>
             <occurrences minimum="1" maximum="1" />
             <config>
-                <option value="h1">H1</option>
                 <option value="h2">H2</option>
                 <option value="h3">H3</option>
                 <option value="h4">H4</option>
                 <option value="h5">H5</option>
                 <option value="h6">H6</option>
             </config>
-            <default>h1</default>
+            <default>h2</default>
         </input>
-        <input name="ingress" type="TextArea">
-            <label>Ingress</label>
-        </input>
+        <mixin name="header-common"/>
     </form>
 </part>

--- a/src/main/resources/site/parts/dynamic-link-list/dynamic-link-list.xml
+++ b/src/main/resources/site/parts/dynamic-link-list/dynamic-link-list.xml
@@ -1,5 +1,5 @@
 <part xmlns="urn:enonic:xp:model:1.0">
-    <display-name>Lenkeliste</display-name>
+    <display-name>_Lenkeliste</display-name>
     <form>
         <input name="title" type="TextLine">
             <label>Tittel</label>

--- a/src/main/resources/site/parts/dynamic-link-panel/dynamic-link-panel.xml
+++ b/src/main/resources/site/parts/dynamic-link-panel/dynamic-link-panel.xml
@@ -1,5 +1,5 @@
 <part xmlns="urn:enonic:xp:model:1.0">
-    <display-name>Lenkepanel</display-name>
+    <display-name>_Lenkepanel</display-name>
     <description>Med valgfri ikon/bakgrunn</description>
     <form>
         <mixin name="link-with-ingress" />

--- a/src/main/resources/site/parts/dynamic-news-list/dynamic-news-list.xml
+++ b/src/main/resources/site/parts/dynamic-news-list/dynamic-news-list.xml
@@ -1,5 +1,5 @@
 <part xmlns="urn:enonic:xp:model:1.0">
-    <display-name>Nyhetsliste</display-name>
+    <display-name>_Nyhetsliste</display-name>
     <form>
         <input name="title" type="TextLine">
             <label>Tittel</label>

--- a/src/main/resources/site/parts/dynamic-read-more-panel/dynamic-read-more-panel.xml
+++ b/src/main/resources/site/parts/dynamic-read-more-panel/dynamic-read-more-panel.xml
@@ -1,5 +1,5 @@
 <part xmlns="urn:enonic:xp:model:1.0">
-    <display-name>Dynamisk les-mer panel</display-name>
+    <display-name>_Les-mer panel</display-name>
     <description>https://design.nav.no/components/lesmerpanel</description>
     <form>
         <input type="TextArea" name="ingress">

--- a/src/main/resources/site/parts/dynamic-supervisor-panel/dynamic-supervisor-panel.xml
+++ b/src/main/resources/site/parts/dynamic-supervisor-panel/dynamic-supervisor-panel.xml
@@ -1,5 +1,5 @@
 <part xmlns="urn:enonic:xp:model:1.0">
-    <display-name>Dynamisk veilederpanel</display-name>
+    <display-name>_Veilederpanel</display-name>
     <description>Innhold av HTML</description>
     <form>
         <input type="HtmlArea" name="content">

--- a/src/main/resources/site/parts/html-area/html-area.es6
+++ b/src/main/resources/site/parts/html-area/html-area.es6
@@ -1,0 +1,3 @@
+const controller = require('/lib/headless/controllers/component-preview-controller');
+
+exports.get = controller;

--- a/src/main/resources/site/parts/html-area/html-area.xml
+++ b/src/main/resources/site/parts/html-area/html-area.xml
@@ -1,0 +1,15 @@
+<part xmlns="urn:enonic:xp:model:1.0">
+    <display-name>_Formattert innhold</display-name>
+    <description>Komponent for rikt tekstinnhold, bilder, mm</description>
+    <form>
+        <input type="HtmlArea" name="html">
+            <label>Innhold</label>
+            <occurrences minimum="1" maximum="1"/>
+            <config>
+                <include>Undo Redo</include>
+                <exclude>JustifyBlock Underline</exclude>
+                <allowHeadings>h3 normal</allowHeadings>
+            </config>
+        </input>
+    </form>
+</part>

--- a/src/main/resources/site/parts/page-header/page-header.es6
+++ b/src/main/resources/site/parts/page-header/page-header.es6
@@ -1,0 +1,3 @@
+const controller = require('/lib/headless/controllers/component-preview-controller');
+
+exports.get = controller;

--- a/src/main/resources/site/parts/page-header/page-header.xml
+++ b/src/main/resources/site/parts/page-header/page-header.xml
@@ -1,0 +1,7 @@
+<part>
+    <display-name>_Header for side (H1)</display-name>
+    <description>Skal kun benyttes som side-tittel</description>
+    <form>
+        <mixin name="page-header"/>
+    </form>
+</part>


### PR DESCRIPTION
- Fjerner mulighet for H1 tag på dynamic-header
- Legger til mulighet for anchorid på dynamic-header

- Nye mixins:
  - Mixin for felter på dynamic-header og andre header-komponenter: Venstre/midt/høyre-justering og typografi
  - Mixin for lenke (intern eller ekstern)
 
- Nye parts-komponenter:
  - html-area
  - page-header (H1-header)
  - button (designsystemets knapp)