### PR TITLE
Egen region for introtekst ved filtrering

### DIFF
--- a/src/main/resources/site/layouts/section-with-header/section-with-header.xml
+++ b/src/main/resources/site/layouts/section-with-header/section-with-header.xml
@@ -64,6 +64,7 @@
         </item-set>
     </form>
     <regions>
+        <region name="intro"/>
         <region name="content"/>
     </regions>
 </layout>


### PR DESCRIPTION
Legger til egen region som kun vil være synlig i Content Studio dersom det allerede finnes parts som har fått satt filtere på seg.