### PR TITLE
Cache-wipe for sider med custom path

### DIFF
--- a/src/main/resources/lib/siteCache/index.es6
+++ b/src/main/resources/lib/siteCache/index.es6
@@ -329,8 +329,11 @@ function clearProductCardMacroReferences(id) {
 
 function clearCustomPathEntry(id) {
     const contentCustomPath = getCustomPathFromContent(id);
-    // check custom path & id equality to prevent infinite loop
-    if (contentCustomPath && contentCustomPath !== id) {
+    if (contentCustomPath) {
+        if (contentCustomPath === id) {
+            log.warning(`Content with custom path set to the actual path detected: ${id}`);
+            return;
+        }
         wipeOnChange(contentCustomPath);
     }
 }


### PR DESCRIPTION
Sørger for at cache-entries som bruker custompath/kort-url som key også blir wipet når den fulle path'en til innholdet wipes.