### PR TITLE
Macro for ingress

### DIFF
--- a/src/main/resources/lib/headless/guillotine/queries/fragments/_processedHtml.es6
+++ b/src/main/resources/lib/headless/guillotine/queries/fragments/_processedHtml.es6
@@ -42,11 +42,15 @@ const macrosFragment = `
         }
         header_with_anchor {
             text
+            body
             id
             tag
         }
         infoBoks {
             infoBoks
+        }
+        ingress {
+            body
         }
         lenkeFiler {
             text

--- a/src/main/resources/site/macros/header-with-anchor/header-with-anchor.xml
+++ b/src/main/resources/site/macros/header-with-anchor/header-with-anchor.xml
@@ -2,7 +2,7 @@
     <display-name>Header med anker-id (H3/H4)</display-name>
     <description>Header som kan lenkes til med hash/anker-id, f.eks nav.no/no/min-side#mitt-anker-id</description>
     <form>
-        <input name="text" type="TextLine">
+        <input name="body" type="TextLine">
             <label>Tekst</label>
             <occurrences minimum="1" maximum="1"/>
         </input>
@@ -18,6 +18,13 @@
                 <option value="h4">H4</option>
             </config>
             <default>h3</default>
+        </input>
+        <input name="text" type="TextLine">
+            <label>(Deprecated - Bruk "Tekst" feltet)</label>
+            <occurrences minimum="0" maximum="1"/>
+            <config>
+                <regexp>^$</regexp>
+            </config>
         </input>
     </form>
 </macro>

--- a/src/main/resources/site/macros/ingress/ingress.xml
+++ b/src/main/resources/site/macros/ingress/ingress.xml
@@ -1,0 +1,10 @@
+<macro>
+    <display-name>Ingress-tekst</display-name>
+    <description>Tekst med 20px størrelse</description>
+    <form>
+        <input name="body" type="TextArea">
+            <label>Tekst</label>
+            <occurrences minimum="1" maximum="1"/>
+        </input>
+    </form>
+</macro>


### PR DESCRIPTION
- Macro for ingress
- Bruker body-felt for tekst i header-macro, for litt penere markup ([header-with-anchor]Header tekst goes here[/header-with-anchor] istedenfor [header-with-anchor tekst="Header tekst goes here"/]