### PR TITLE
Fjerner ubrukt felt "className" fra fasetter

### DIFF
--- a/src/main/resources/lib/facets/index.es6
+++ b/src/main/resources/lib/facets/index.es6
@@ -170,7 +170,6 @@ const updateFacets = (fasetter, ids) => {
                 t.push({
                     fasett: el.name,
                     underfasett: value.name,
-                    className: value.className,
                     query:
                         el.rulekey +
                         ' LIKE "' +
@@ -212,7 +211,6 @@ const updateFacets = (fasetter, ids) => {
             fasett: value.fasett,
         };
         if (value.underfasett) fasett.underfasett = value.underfasett;
-        if (value.className) fasett.className = value.className;
         let start = 0;
         let count = 1000;
         let hits = [];

--- a/src/main/resources/site/x-data/fasetter/fasetter.xml
+++ b/src/main/resources/site/x-data/fasetter/fasetter.xml
@@ -10,9 +10,5 @@
             <label>Underfasett</label>
             <occurrences minimum="0" maximum="1"/>
         </input>
-        <input type="TextLine" name="className">
-            <label>Class name</label>
-            <occurrences minimum="0" maximum="1"/>
-        </input>
     </form>
 </x-data>


### PR DESCRIPTION
Feltet har ikke være i bruk siden vi fikk ny søk-frontend, og jeg fjernet den også fra søk-backenden ved siste prodsetting der.