### PR TITLE
Legger til tomme definisjoner av gamle innholdstyper for å unngå problemer i XP 7.7 og CS 3.3

### DIFF
--- a/src/main/resources/site/content-types/cms2xp_page/cms2xp_page.xml
+++ b/src/main/resources/site/content-types/cms2xp_page/cms2xp_page.xml
@@ -1,7 +1,10 @@
 <content-type>
     <display-name>Cms2xp_page - Skal ikke brukes</display-name>
-    <description>Utgått innholdstype fra Enonic CMS</description>
-    <config>
-        <allow-new-content>false</allow-new-content>
-    </config>
+    <description>
+        Utgått innholdstype fra Enonic CMS - må være definert for å unngå krasj i Content Studio
+    </description>
+    <super-type>base:structured</super-type>
+    <is-abstract>true</is-abstract>
+    <form>
+    </form>
 </content-type>

--- a/src/main/resources/site/content-types/cms2xp_section/cms2xp_section.xml
+++ b/src/main/resources/site/content-types/cms2xp_section/cms2xp_section.xml
@@ -1,7 +1,10 @@
 <content-type>
     <display-name>Cms2xp_section - Skal ikke brukes</display-name>
-    <description>Utgått innholdstype fra Enonic CMS</description>
-    <config>
-        <allow-new-content>false</allow-new-content>
-    </config>
+    <description>
+        Utgått innholdstype fra Enonic CMS - må være definert for å unngå krasj i Content Studio
+    </description>
+    <super-type>base:structured</super-type>
+    <is-abstract>true</is-abstract>
+    <form>
+    </form>
 </content-type>

--- a/src/main/resources/site/content-types/generic-page/generic-page.xml
+++ b/src/main/resources/site/content-types/generic-page/generic-page.xml
@@ -1,7 +1,10 @@
 <content-type>
     <display-name>Generic page - Skal ikke brukes</display-name>
-    <description>Utgått innholdstype - må være definert for å unngå krasj i Content Studio</description>
-    <config>
-        <allow-new-content>false</allow-new-content>
-    </config>
+    <description>
+        Utgått innholdstype - må være definert for å unngå krasj i Content Studio
+    </description>
+    <super-type>base:structured</super-type>
+    <is-abstract>true</is-abstract>
+    <form>
+    </form>
 </content-type>

--- a/src/main/resources/site/content-types/link-list/link-list.xml
+++ b/src/main/resources/site/content-types/link-list/link-list.xml
@@ -1,7 +1,10 @@
 <content-type>
     <display-name>link-list - Skal ikke brukes</display-name>
-    <description>Utgått innholdstype fra Enonic CMS</description>
-    <config>
-        <allow-new-content>false</allow-new-content>
-    </config>
+    <description>
+        Utgått innholdstype fra Enonic CMS - må være definert for å unngå krasj i Content Studio
+    </description>
+    <super-type>base:structured</super-type>
+    <is-abstract>true</is-abstract>
+    <form>
+    </form>
 </content-type>


### PR DESCRIPTION
Lagt til gamle innholdsttyper for å få CS til å fungere.