### PR TITLE
Dummy-felt for fasett-classname

### DIFF
--- a/src/main/resources/site/x-data/fasetter/fasetter.xml
+++ b/src/main/resources/site/x-data/fasetter/fasetter.xml
@@ -10,5 +10,13 @@
             <label>Underfasett</label>
             <occurrences minimum="0" maximum="1"/>
         </input>
+        <!--
+            Dummy value to prevent Elasticsearch error due to missing property mapping
+            (this is a legacy field no longer in use)
+        -->
+        <input type="RadioButton" name="className">
+            <label>-</label>
+            <occurrences minimum="0" maximum="1"/>
+        </input>
     </form>
 </x-data>


### PR DESCRIPTION
Gjeninnfører et dummy-felt for className på fasetter for å hindre potensielle krasj pga divergerende datamodell.