### PR TITLE
Bruker globale verdier kun fra master i macroer

### DIFF
--- a/src/main/resources/lib/headless/guillotine/schema-creation-callbacks/global-value-macro-config.es6
+++ b/src/main/resources/lib/headless/guillotine/schema-creation-callbacks/global-value-macro-config.es6
@@ -1,4 +1,5 @@
 const graphQlLib = require('/lib/guillotine/graphql');
+const { runInBranchContext } = require('/lib/headless/branch-context');
 const { getGlobalNumberValue, getGlobalTextValue } = require('/lib/global-values/global-values');
 const { forceArray } = require('/lib/nav-utils');
 
@@ -6,7 +7,7 @@ const globalValueMacroConfigCallback = (context, params) => {
     params.fields.value = {
         type: graphQlLib.GraphQLString,
         resolve: (env) => {
-            return getGlobalTextValue(env.source.key);
+            return runInBranchContext(() => getGlobalTextValue(env.source.key), 'master');
         },
     };
 };
@@ -16,10 +17,14 @@ const globalValueWithMathMacroConfigCallback = (context, params) => {
         type: graphQlLib.list(graphQlLib.GraphQLFloat),
         resolve: (env) => {
             const keys = forceArray(env.source.keys);
-            const variables = keys.reduce((acc, key) => {
-                const value = getGlobalNumberValue(key);
-                return value ? [...acc, value] : acc;
-            }, []);
+            const variables = runInBranchContext(
+                () =>
+                    keys.reduce((acc, key) => {
+                        const value = getGlobalNumberValue(key);
+                        return value ? [...acc, value] : acc;
+                    }, []),
+                'master'
+            );
 
             // If any specified variables are missing, we return nothing to ensure
             // inconsistent/unintended calculations does not happen

--- a/src/main/resources/services/globalValues/globalValues.es6
+++ b/src/main/resources/services/globalValues/globalValues.es6
@@ -1,3 +1,4 @@
+const { runInBranchContext } = require('/lib/headless/branch-context');
 const { getSubPath } = require('../service-utils');
 const { getGlobalValueSetService } = require('./getSet/getSet');
 const { removeGlobalValueItem } = require('./remove/remove');
@@ -14,7 +15,10 @@ const selectorHandler = (req) => {
         .map((word) => `${word}*`)
         .join(' ');
 
-    const values = getAllGlobalValues(valueType, wordsWithWildcard);
+    const values = runInBranchContext(
+        () => getAllGlobalValues(valueType, wordsWithWildcard),
+        'master'
+    );
 
     const hits = values
         .map((value) => ({


### PR DESCRIPTION
Hindrer forvirrende oppførsel der macroer med upubliserte verdier kan gi feil resultat i prod men se ok ut i CS