### PR TITLE
Flyttet variabelName-felt lenger ned

### DIFF
--- a/src/main/resources/site/content-types/calculator/calculator.xml
+++ b/src/main/resources/site/content-types/calculator/calculator.xml
@@ -12,10 +12,6 @@
                     <label>Nummerfelt</label>
                     <help-text>Alle inputfelt blir automatisk begrenset til å kun inneholde tall.</help-text>
                     <items>
-                        <input name="variableName" type="TextLine">
-                            <label>Variabelnavn</label>
-                            <help-text>Brukes til å henvise referanse i selve utregningen nedenfor.</help-text>
-                        </input>
                         <input name="label" type="TextLine">
                             <label>Tittel på felt</label>
                         </input>
@@ -23,15 +19,15 @@
                             <label>Forklaring</label>
                             <help-text>Oppgi en ekstra forklaring til feltet dersom det er nødvendig.</help-text>
                         </input>
+                        <input name="variableName" type="TextLine">
+                            <label>Javascript variabelnavn (skal normalt ikke endres)</label>
+                            <help-text>Brukes til å henvise referanse i selve utregningen nedenfor.</help-text>
+                        </input>
                     </items>
                 </option>
                 <option name="dropdownField">
                     <label>Listevalg</label>
                     <items>
-                        <input name="variableName" type="TextLine">
-                            <label>Variabelnavn</label>
-                            <help-text>Brukes til å henvise referanse i selve utregningen nedenfor.</help-text>
-                        </input>
                         <input name="label" type="TextLine">
                             <label>Tittel på felt</label>
                         </input>
@@ -51,15 +47,15 @@
                             <label>Forklaring</label>
                             <help-text>Oppgi en ekstra forklaring til feltet dersom det er nødvendig.</help-text>
                         </input>
+                        <input name="variableName" type="TextLine">
+                            <label>Javascript variabelnavn (skal normalt ikke endres)</label>
+                            <help-text>Brukes til å henvise referanse i selve utregningen nedenfor.</help-text>
+                        </input>
                     </items>
                 </option>
                 <option name="globalValue">
                     <label>Global verdi</label>
                     <items>
-                        <input name="variableName" type="TextLine">
-                            <label>Variabelnavn</label>
-                            <help-text>Brukes til å henvise referanse i selve utregningen nedenfor.</help-text>
-                        </input>
                         <input name="key" type="CustomSelector">
                             <label>Velg verdier</label>
                             <occurrences minimum="1" maximum="1"/>
@@ -67,6 +63,10 @@
                                 <service>globalValues</service>
                                 <param value="valueType">numberValue</param>
                             </config>
+                        </input>
+                        <input name="variableName" type="TextLine">
+                            <label>Javascript variabelnavn (skal normalt ikke endres)</label>
+                            <help-text>Brukes til å henvise referanse i selve utregningen nedenfor.</help-text>
                         </input>
                         <!-- Dummy value to prevent graphql-errors for undefined field -->
                         <input name="value" type="RadioButton">


### PR DESCRIPTION
- Flyttet feltet lenger ned for å holde det unna tittelfelt.
- Endret feltnavn for tydelighet
- Mål om å unngå forvirring fra redaktørene.

<img width="636" alt="Screenshot 2021-09-15 at 14 47 49" src="https://user-images.githubusercontent.com/1443997/133436121-d5d27173-b7d5-484d-a862-a2b1c02f3903.png">