### PR TITLE
Fikser valg av publiseringstidspunkt i versjonshistorikk for fragmenter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
             "integrity": "sha512-cVB+dXeGhMOqViIaZs3A9OUAe4pKw4SBNdMw6yHJMYR7s4TB+Cei7ThquV/84O19PdIFWuwe03vxxES0BHUm5g==",
             "dev": true,
             "dependencies": {
-                "chokidar": "^2.1.8",
                 "commander": "^4.0.1",
                 "convert-source-map": "^1.1.0",
                 "fs-readdir-recursive": "^1.1.0",
@@ -4320,7 +4319,6 @@
             "dependencies": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
-                "fsevents": "~2.1.2",
                 "glob-parent": "~5.1.0",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",

--- a/src/main/resources/lib/headless/guillotine/queries/sitecontent.es6
+++ b/src/main/resources/lib/headless/guillotine/queries/sitecontent.es6
@@ -112,22 +112,30 @@ const getContent = (contentRef, branch) => {
 
     const contentWithParsedData = deepJsonParser(content, ['data', 'config', 'page']);
 
+    const publishedVersionTimestamps = getPublishedVersionTimestamps(contentRef, branch);
+
+    const commonFields = {
+        components: undefined,
+        pathMap: getPathMapForReferences(contentRef),
+        ...(publishedVersionTimestamps && { versionTimestamps: publishedVersionTimestamps }),
+    };
+
+    // This is the preview/editor page for fragments (not user-facing). It requires some
+    // special handling for its contained components
     if (content.__typename === 'portal_Fragment') {
-        return getPortalFragmentContent(contentWithParsedData);
+        return {
+            ...getPortalFragmentContent(contentWithParsedData),
+            ...commonFields,
+        };
     }
 
-    const page = mergeComponentsIntoPage(contentWithParsedData);
     const breadcrumbs = runInBranchContext(() => menuUtils.getBreadcrumbMenu(contentRef), branch);
-    const pathMap = getPathMapForReferences(contentRef);
-    const publishedVersionTimestamps = getPublishedVersionTimestamps(contentRef, branch);
 
     return {
         ...contentWithParsedData,
-        page,
-        components: undefined,
+        ...commonFields,
         ...(breadcrumbs && { breadcrumbs }),
-        pathMap,
-        ...(publishedVersionTimestamps && { versionTimestamps: publishedVersionTimestamps }),
+        page: mergeComponentsIntoPage(contentWithParsedData),
     };
 };
 

--- a/src/main/resources/lib/headless/process-components.es6
+++ b/src/main/resources/lib/headless/process-components.es6
@@ -164,7 +164,6 @@ const getPortalFragmentContent = (content) => {
     return {
         ...content,
         fragment: { ...insertComponentsIntoFragment(rootComponent, components).fragment },
-        components: undefined,
     };
 };
 


### PR DESCRIPTION
Inkluderer versions-timestamps (og pathmaps for kort-urler) i portal_Fragment-sider fra sitecontent