### PR TITLE
Mini og mikrokort overskrift

### DIFF
--- a/src/main/resources/site/mixins/product-card-mini/product-card-mini.xml
+++ b/src/main/resources/site/mixins/product-card-mini/product-card-mini.xml
@@ -3,7 +3,7 @@
         <field-set>
             <label>Produkt eller livssituasjon</label>
             <items>
-                <input name="title" type="TextLine">
+                <input name="header" type="TextLine">
                     <label>Overskrift</label>
                     <help-text>Overskrift er ikke påkrevet</help-text>
                 </input>

--- a/src/main/resources/site/parts/product-card-micro/product-card-micro.xml
+++ b/src/main/resources/site/parts/product-card-micro/product-card-micro.xml
@@ -2,7 +2,7 @@
     <display-name>_Kort mikro</display-name>
     <description>Lenker til en produkt- eller livssituasjons-side</description>
     <form>
-        <input name="title" type="TextLine">
+        <input name="header" type="TextLine">
             <label>Overskrift</label>
             <help-text>Overskrift er ikke påkrevet</help-text>
         </input>


### PR DESCRIPTION
Tittelen ovenfor mini- og mikrokort bør behandles som en del av én part istedet for å bli bygget opp av flere parts, sistnevnte kan skape feil bruk av overskrift.

![Screenshot 2021-09-23 at 08 09 03](https://user-images.githubusercontent.com/1443997/134461397-4f1b8827-7957-4756-b982-e9fc2566aa57.png)
