### PR TITLE
Fikser revaliderings-kall ved publisering for sider med customPath/kort-url

### DIFF
--- a/src/main/resources/lib/headless/frontend-cache-revalidate.es6
+++ b/src/main/resources/lib/headless/frontend-cache-revalidate.es6
@@ -1,4 +1,5 @@
 const httpClient = require('/lib/http-client');
+const { getCustomPathFromContent } = require('/lib/custom-paths/custom-paths');
 const { revalidatorProxyOrigin } = require('/lib/headless/url-origin');
 
 const numRetries = 2;
@@ -6,7 +7,7 @@ const numRetries = 2;
 const requestRevalidate = (path, retriesLeft = numRetries) => {
     try {
         httpClient.request({
-            url: `${revalidatorProxyOrigin}/revalidator-proxy?path=${path}`,
+            url: `${revalidatorProxyOrigin}/revalidator-proxy?path=${encodeURI(path)}`,
             method: 'GET',
             connectionTimeout: 1000,
             contentType: 'application/json',
@@ -24,12 +25,16 @@ const requestRevalidate = (path, retriesLeft = numRetries) => {
     }
 };
 
-const frontendCacheRevalidate = (path) => {
-    if (!path) {
+const frontendCacheRevalidate = (pathname) => {
+    if (!pathname) {
         return;
     }
 
-    requestRevalidate(path);
+    // If the content has a custom path, the frontend will use this as key for its cache
+    // Make sure we send this path to the revalidator proxy
+    const customPath = getCustomPathFromContent(`/www.nav.no${pathname}`);
+
+    requestRevalidate(customPath || pathname);
 };
 
 module.exports = { frontendCacheRevalidate };

--- a/src/main/resources/lib/siteCache/index.es6
+++ b/src/main/resources/lib/siteCache/index.es6
@@ -1,5 +1,4 @@
 const contentLib = require('/lib/xp/content');
-const { getCustomPathFromContent } = require('/lib/custom-paths/custom-paths');
 const { removeDuplicates } = require('/lib/nav-utils');
 const { runInBranchContext } = require('/lib/headless/branch-context');
 const { globalValuesContentType } = require('/lib/global-values/global-values');
@@ -126,17 +125,13 @@ function wipeOnChange(path) {
         return true;
     }
 
-    // Cache for sitecontent uses the custom path of a page as key, if it exists
-    const customPath = getCustomPathFromContent(`/www.nav.no${pathname}`);
-    const cacheKey = customPath || pathname;
-
     // Wipe cache for frontend sitecontent service
-    wipe('sitecontent')(cacheKey);
+    wipe('sitecontent')(pathname);
     if (libs.cluster.isMaster()) {
         libs.task.submit({
-            description: `send revalidate on ${cacheKey}`,
+            description: `send revalidate on ${pathname}`,
             task: () => {
-                frontendCacheRevalidate(encodeURI(cacheKey));
+                frontendCacheRevalidate(pathname);
             },
         });
     }


### PR DESCRIPTION
Sider som har custompath bruker denne som cache-nøkkel i frontend, fremfor den interne xp-pathen. Denne PR'en fikser det slik at kallet til revalidator-proxyen tar hensyn til dette.