### PR TITLE
Fiks for lenker til "external-link" objekter

### DIFF
--- a/src/main/resources/lib/headless/guillotine/queries/fragments/_mixins.es6
+++ b/src/main/resources/lib/headless/guillotine/queries/fragments/_mixins.es6
@@ -1,6 +1,7 @@
 const globalFragment = require('./_global');
 const internalLink = require('./internalLink');
 const externalLink = require('./externalLink');
+const url = require('./url');
 const animatedIconsFragment = require('./animatedIcons');
 
 const languagesMixinFragment = `
@@ -42,6 +43,8 @@ const decoratorTogglesMixinFragment = `
 const linkInternalMixinFragment = `
     target {
         ${globalFragment}
+        ${externalLink.fragment}
+        ${url.fragment}
     }
     text
 `;


### PR DESCRIPTION
Inkluderer fragmenter for eksterne lenker i mixin for lenke til internt innhold (ja det var forvirrende, men external-link objekter er altså internt innhold!)