### PR TITLE
Støtte for query på ufullstendige ord i fragment-selector

### DIFF
--- a/src/main/resources/services/htmlFragmentSelector/htmlFragmentSelector.es6
+++ b/src/main/resources/services/htmlFragmentSelector/htmlFragmentSelector.es6
@@ -37,7 +37,7 @@ const selectorHandler = (req) => {
     }
 
     const htmlFragments = contentLib.query({
-        ...(query && { query: `fulltext("displayName, _path", "${query}", "AND")` }),
+        ...(query && { query: `displayName LIKE "*${query}*"` }),
         start: 0,
         count: 10000,
         contentTypes: ['portal:fragment'],


### PR DESCRIPTION
Bruker wildcards på query for fragmenter i htmlFragmentSelector, slik at det vises treff på ufullstendige ord.