### PR TITLE
Fjerner textValue og relevante hjelpere i forbindelse med forenkling av globale verdier

### DIFF
--- a/src/main/resources/lib/global-values/global-values.es6
+++ b/src/main/resources/lib/global-values/global-values.es6
@@ -4,7 +4,7 @@ const { findContentsWithHtmlAreaText } = require('/lib/htmlarea/htmlarea');
 const { forceArray } = require('/lib/nav-utils');
 
 const globalValuesContentType = `${app.name}:global-value-set`;
-const validTypes = { textValue: true, numberValue: true };
+const validTypes = { numberValue: true };
 
 const uniqueKeySeparator = '::';
 
@@ -216,15 +216,12 @@ const getGlobalValue = (gvKey, contentId, type) => {
     return value[type] || value.numberValue;
 };
 
-const getGlobalTextValue = (gvKey, contentId) => getGlobalValue(gvKey, contentId, 'textValue');
-
 const getGlobalNumberValue = (gvKey, contentId) => getGlobalValue(gvKey, contentId, 'numberValue');
 
 module.exports = {
     getGlobalValueUsage,
     getGlobalValueUsageLegacy,
     getGlobalValueSet,
-    getGlobalTextValue,
     getGlobalNumberValue,
     globalValuesContentType,
     getGlobalValueUniqueKey,

--- a/src/main/resources/lib/headless/guillotine/queries/fragments/globalValueSet.es6
+++ b/src/main/resources/lib/headless/guillotine/queries/fragments/globalValueSet.es6
@@ -4,7 +4,6 @@ const globalValueSetFragment = `
             valueItems {
                 key
                 itemName
-                textValue
                 numberValue
             }
         }

--- a/src/main/resources/lib/headless/guillotine/schema-creation-callbacks/global-value-macro-config.es6
+++ b/src/main/resources/lib/headless/guillotine/schema-creation-callbacks/global-value-macro-config.es6
@@ -1,7 +1,7 @@
 const graphQlLib = require('/lib/guillotine/graphql');
 const { getGvKeyAndContentIdFromUniqueKey } = require('/lib/global-values/global-values');
 const { runInBranchContext } = require('/lib/headless/branch-context');
-const { getGlobalNumberValue, getGlobalTextValue } = require('/lib/global-values/global-values');
+const { getGlobalNumberValue } = require('/lib/global-values/global-values');
 const { forceArray } = require('/lib/nav-utils');
 
 const globalValueMacroConfigCallback = (context, params) => {
@@ -9,13 +9,7 @@ const globalValueMacroConfigCallback = (context, params) => {
         type: graphQlLib.GraphQLString,
         resolve: (env) => {
             const { gvKey, contentId } = getGvKeyAndContentIdFromUniqueKey(env.source.key);
-            return runInBranchContext(() => {
-                // Attempt to prioritize the number value, as this needs to be formatted depending on
-                // content language by frontend.
-                return (
-                    getGlobalNumberValue(gvKey, contentId) || getGlobalTextValue(gvKey, contentId)
-                );
-            }, 'master');
+            return runInBranchContext(() => getGlobalNumberValue(gvKey, contentId), 'master');
         },
     };
 };

--- a/src/main/resources/lib/headless/guillotine/schema-creation-callbacks/global-values.es6
+++ b/src/main/resources/lib/headless/guillotine/schema-creation-callbacks/global-values.es6
@@ -13,7 +13,6 @@ const globalValuesCallback = (context, params) => {
                 fields: {
                     key: { type: graphQlLib.GraphQLString },
                     itemName: { type: graphQlLib.GraphQLString },
-                    textValue: { type: graphQlLib.GraphQLString },
                     numberValue: { type: graphQlLib.GraphQLFloat },
                 },
             })

--- a/src/main/resources/services/globalValues/add/add.es6
+++ b/src/main/resources/services/globalValues/add/add.es6
@@ -16,7 +16,7 @@ const addGlobalValueItemService = (req) => {
         return errorResponse;
     }
 
-    const { contentId, itemName, textValue, numberValue } = req.params;
+    const { contentId, itemName, numberValue } = req.params;
 
     const content = runInBranchContext(() => getGlobalValueSet(contentId), 'draft');
     if (!content) {
@@ -41,7 +41,6 @@ const addGlobalValueItemService = (req) => {
         const newItem = {
             key: generateKey(),
             itemName,
-            ...(textValue && { textValue }),
             ...(numberValue !== undefined && { numberValue }),
         };
 

--- a/src/main/resources/services/globalValues/modify/modify.es6
+++ b/src/main/resources/services/globalValues/modify/modify.es6
@@ -16,7 +16,7 @@ const modifyGlobalValueItemService = (req) => {
         return errorResponse;
     }
 
-    const { contentId, key, itemName, textValue, numberValue } = req.params;
+    const { contentId, key, itemName, numberValue } = req.params;
 
     const content = runInBranchContext(() => getGlobalValueSet(contentId), 'draft');
     if (!content) {
@@ -43,7 +43,6 @@ const modifyGlobalValueItemService = (req) => {
         const modifiedItem = {
             key,
             itemName,
-            ...(textValue && { textValue }),
             ...(numberValue !== undefined && { numberValue }),
         };
 

--- a/src/main/resources/services/globalValues/selector/selector.es6
+++ b/src/main/resources/services/globalValues/selector/selector.es6
@@ -83,7 +83,7 @@ const getHitsFromSelectedIds = (ids, valueType, withDescription) =>
     }, []);
 
 const globalValueSelectorService = (req) => {
-    const { valueType = 'textValue', withDescription, query, ids } = req.params;
+    const { valueType = 'numberValue', withDescription, query, ids } = req.params;
 
     const hits = runInBranchContext(
         () =>

--- a/src/main/resources/services/globalValues/utils.es6
+++ b/src/main/resources/services/globalValues/utils.es6
@@ -3,24 +3,19 @@ const {
     insufficientPermissionResponse,
 } = require('/lib/auth/auth-utils');
 
-const validateGlobalValueInputAndGetErrorResponse = ({
-    contentId,
-    itemName,
-    textValue,
-    numberValue,
-}) => {
+const validateGlobalValueInputAndGetErrorResponse = ({ contentId, itemName, numberValue }) => {
     if (!validateCurrentUserPermissionForContent(contentId, 'MODIFY')) {
         return insufficientPermissionResponse('MODIFY');
     }
 
-    const hasValue = textValue || numberValue !== undefined;
+    const hasValue = numberValue !== undefined;
 
     if (!contentId || !itemName || !hasValue) {
         return gvServiceInvalidRequestResponse(
             'Missing parameters:' +
                 `${!contentId && ' contentId'}` +
                 `${!itemName && ' itemName'}` +
-                `${!hasValue && ' textValue or numberValue'}`
+                `${!hasValue && ' numberValue'}`
         );
     }
 

--- a/src/main/resources/site/macros/global-value/global-value.xml
+++ b/src/main/resources/site/macros/global-value/global-value.xml
@@ -7,7 +7,7 @@
             <occurrences minimum="1" maximum="1"/>
             <config>
                 <service>globalValues</service>
-                <param value="valueType">textValue</param>
+                <param value="valueType">numberValue</param>
                 <param value="withDescription">true</param>
             </config>
         </input>


### PR DESCRIPTION
For å forenkle globale verdier fjerner vi textValue slik at man kun kan legge inn en numerisk verdi. Korrekt formattering med tusenskilletegn og desimalskilletegn håndteres av frontent avhengig av hvilket språk artikkelen er satt til.