### PR TITLE
Logger diff mellom node-id'er og faktisk innhold ved dataquery

### DIFF
--- a/src/main/resources/services/dataQuery/dataQuery.es6
+++ b/src/main/resources/services/dataQuery/dataQuery.es6
@@ -117,16 +117,20 @@ const runQuery = ({ requestId, query, batch, branch, types, fieldKeys }) => {
         },
     });
 
-    // if (result.hits.length !== contentIdsBatch.length) {
-    const diff = contentIdsBatch.filter((id) => !result.hits.find((hit) => hit._id === id));
-    log.info(`Data query: missing results from contentLib query: ${JSON.stringify(diff)}`);
-    // }
+    if (result.hits.length !== contentIdsBatch.length) {
+        const diff = contentIdsBatch.filter((id) => !result.hits.find((hit) => hit._id === id));
+        log.info(
+            `Data query: missing results from contentLib query for ${
+                diff.length
+            } ids: ${JSON.stringify(diff)}`
+        );
+    }
 
     return {
         ...result,
         hits: hitsWithRequestedFields(result.hits, fieldKeys),
         total: contentIds.length,
-        hasMore: contentIds.length >= end,
+        hasMore: contentIds.length > end,
     };
 };
 


### PR DESCRIPTION
Skjer noe rart her på enkelte content id'er som finnes ved node-lib query men ikke ved content-lib query. I dev ser det ut til å skyldes null-objekter i databasen i master-branchen, vil se om det samme finnes i prod.

Fikser også en potensiell off-by-one feil