### PR TITLE
Filtrerer linebreaks og ugyldige tags fra processedHtml

### DIFF
--- a/src/main/resources/lib/headless/guillotine/guillotine-schema.es6
+++ b/src/main/resources/lib/headless/guillotine/guillotine-schema.es6
@@ -7,6 +7,7 @@ const rootSubscriptionLib = require('/lib/guillotine/subscription/root-subscript
 const sectionPageDataCallback = require('./schema-creation-callbacks/section-page-data');
 const { menuListDataCallback } = require('./schema-creation-callbacks/menu-list-data');
 const contentListCallback = require('./schema-creation-callbacks/content-list-callback');
+const { richTextCallback } = require('/lib/headless/guillotine/schema-creation-callbacks/richtext');
 const { mediaCodeCallback } = require('./schema-creation-callbacks/media');
 const { attachmentCallback } = require('./schema-creation-callbacks/attachment');
 const { macroHtmlFragmentCallback } = require('./schema-creation-callbacks/macro-html-fragment');
@@ -84,6 +85,7 @@ const schemaContextOptions = {
         Macro_no_nav_navno_global_value_DataConfig: globalValueMacroConfigCallback,
         Macro_no_nav_navno_global_value_with_math_DataConfig: globalValueWithMathMacroConfigCallback,
         Macro_no_nav_navno_html_fragment_DataConfig: macroHtmlFragmentCallback,
+        RichText: richTextCallback,
     }),
     applications: [app.name, 'navno.nav.no.search', 'com.enonic.app.rss'],
     allowPaths: ['/redirects'],

--- a/src/main/resources/lib/headless/guillotine/schema-creation-callbacks/richtext.es6
+++ b/src/main/resources/lib/headless/guillotine/schema-creation-callbacks/richtext.es6
@@ -1,0 +1,21 @@
+const macroTagName = 'editor-macro';
+const macroTagStart = `<${macroTagName}`;
+const macroTagEnd = `</${macroTagName}>`;
+
+const linebreaksFilter = new RegExp(/(\r\n|\n|\r|\s)/gi);
+
+// The content studio editor inserts <p>-tags around macros. This causes potential issues with
+// invalid tag-nesting, so we remove these.
+const macroStartFilter = new RegExp(`<p>${macroTagStart}`, 'gi');
+const macroEndFilter = new RegExp(`${macroTagEnd}</p>`, 'gi');
+
+const richTextCallback = (context, params) => {
+    params.fields.processedHtml.resolve = (env) => {
+        return env.source.processedHtml
+            .replace(linebreaksFilter, ' ')
+            .replace(macroStartFilter, macroTagStart)
+            .replace(macroEndFilter, macroTagEnd);
+    };
+};
+
+module.exports = { richTextCallback };


### PR DESCRIPTION
Filtrerer vekk p-tags rundt macroer, og fjerner linebreaks fra html'en. Fjerner tilsvarende i frontend her: https://github.com/navikt/nav-enonicxp-frontend/pull/643. Det ble litt enklere/mer effektivt å håndtere dette på backend.