### PR TITLE
Fikser invalid html-nesting i enkelte macroer

### DIFF
--- a/src/main/resources/lib/headless/guillotine/schema-creation-callbacks/richtext.es6
+++ b/src/main/resources/lib/headless/guillotine/schema-creation-callbacks/richtext.es6
@@ -11,7 +11,7 @@ const richTextCallback = (context, params) => {
         const { processedHtml } = env.source;
 
         return processedHtml
-            ? env.source.processedHtml
+            ? processedHtml
                   // Strip linebreaks, as it may cause errors in the frontend parser
                   .replace(linebreakFilter, ' ')
                   // Strip html tags from the body of macro-tags. Fixes invalid html-nesting caused by the CS editor


### PR DESCRIPTION
Dersom en macro har et "body" felt fører dette til ugyldig tag-nesting dersom body'en inneholder linjeskift. CS editoren setter inn p-tagger ved linjeskift uten å ta hensyn til macro-tagger, dermed kan en få slike konstruksjoner:

```
<p><editor-macro data-macro-name="foo" data-macro-ref="some-uuid">Some content goes here</p>

<p>More content here!</p>

<p></editor-macro></p>
```

Fikser dette ved å strippe vekk alle html-tags fra editor-macro tag'ene. Macroer skal uansett ikke inneholde ikke-encodet html.