### PR TITLE
Skriver om html-area query til å benytte fulltext-søk

### DIFF
--- a/src/main/resources/lib/htmlarea/htmlarea.es6
+++ b/src/main/resources/lib/htmlarea/htmlarea.es6
@@ -15,6 +15,10 @@ const htmlAreaNodePaths = [
 const htmlAreaNodePathsString = htmlAreaNodePaths.join(',');
 
 const findContentsWithHtmlAreaText = (text) => {
+    if (!text) {
+        return [];
+    }
+
     const queryHits = contentLib.query({
         start: 0,
         count: 1000,


### PR DESCRIPTION
Dette brukes bl.a. til å sjekke bruk av globale verdier og fragmenter i macroer. Wildcard-søket som brukes i dag ser ikke ut til å gi konsistente resultater. 