### PR TITLE
Viser verdi-navn i description for global-values selector

### DIFF
--- a/src/main/resources/services/globalValues/selector/selector.es6
+++ b/src/main/resources/services/globalValues/selector/selector.es6
@@ -16,7 +16,7 @@ const hitFromValueItem = (valueItem, valueType, content, withDescription) => {
     return {
         id: withDescription ? appendMacroDescriptionToKey(key, displayName) : key,
         displayName: `${displayName} - ${valueItem.key}`,
-        description: `Verdi: ${valueItem[valueType]}`,
+        description: `${valueItem.itemName} - Verdi: ${valueItem[valueType]}`,
     };
 };
 


### PR DESCRIPTION
Gjør det enklere å finne verdier fra et objekt med langt displayName