### PR TITLE
Fikser regexp config for 7.8

### DIFF
--- a/src/main/resources/site/macros/chevron-link-external/chevron-link-external.xml
+++ b/src/main/resources/site/macros/chevron-link-external/chevron-link-external.xml
@@ -7,9 +7,7 @@
             <default>https://</default>
             <occurrences minimum="1" maximum="1"/>
             <config>
-                <regexp>
-                    ^https?:\/\/.*
-                </regexp>
+                <regexp>^https?:\/\/</regexp>
             </config>
         </input>
         <input name="text" type="TextLine">

--- a/src/main/resources/site/macros/video/video.xml
+++ b/src/main/resources/site/macros/video/video.xml
@@ -8,7 +8,7 @@
             <occurrences minimum="1" maximum="1"/>
             <default>https://video.qbrick.com/</default>
             <config>
-                <regexp>^(https://video.qbrick.com/)</regexp>
+                <regexp>^https:\/\/video\.qbrick\.com\/.+</regexp>
             </config>
         </input>
         <input name="title" type="TextLine">

--- a/src/main/resources/site/mixins/link-external/link-external.xml
+++ b/src/main/resources/site/mixins/link-external/link-external.xml
@@ -6,9 +6,7 @@
             <default>https://</default>
             <occurrences minimum="1" maximum="1"/>
             <config>
-                <regexp>
-                    ^https?:\/\/.*
-                </regexp>
+                <regexp>^https?:\/\/</regexp>
             </config>
         </input>
         <input name="text" type="TextLine">

--- a/src/main/resources/site/mixins/link-panels/link-panels.xml
+++ b/src/main/resources/site/mixins/link-panels/link-panels.xml
@@ -36,9 +36,7 @@
                                         Legg url på formen https://*.nav.no/* - Hvis innhold velges under, vil dette overstyre url
                                     </help-text>
                                     <config>
-                                        <regexp>
-                                            (?:https:\/\/)[\w.-]+(?:\.nav\.no\/)[\w\-\._~:\/?#\[\]@!\$\&amp;\'\(\)\*\+,;=.]*
-                                        </regexp>
+                                        <regexp>^https:\/\/([a-z0-9_\-.]*\.)?nav\.no($|\/)</regexp>
                                     </config>
                                 </input>
                                 <input name="ref" type="ContentSelector">

--- a/src/main/resources/site/mixins/seo/seo.xml
+++ b/src/main/resources/site/mixins/seo/seo.xml
@@ -24,9 +24,7 @@
                     </help-text>
                     <occurrences minimum="0" maximum="1"/>
                     <config>
-                        <regexp>
-                            (?:https:\/\/)[\w.-]+(?:\.nav\.no\/)[\w\-\._~:\/?#\[\]@!\$\&amp;\'\(\)\*\+,;=.]*
-                        </regexp>
+                        <regexp>^https:\/\/([a-z0-9_\-.]*\.)?nav\.no($|\/)</regexp>
                     </config>
                 </input>
                 <input name="noindex" type="CheckBox">

--- a/src/main/resources/site/parts/contact-option/contact-option.xml
+++ b/src/main/resources/site/parts/contact-option/contact-option.xml
@@ -36,9 +36,7 @@
                             <label>Telefonnummer</label>
                             <default>55 55 33 33</default>
                             <config>
-                                <regexp>
-                                    ^[0-9+ ]+$
-                                </regexp>
+                                <regexp>^[0-9+ ]+$</regexp>
                             </config>
                         </input>
                         <input name="ingress" type="TextArea">


### PR DESCRIPTION
XP versjon 7.8.* ser ut til å parse linebreaks i regex'er i xml-filene. Fjerner derfor disse (og rydder litt i regex-uttrykkene, ettersom jeg først trodde det var disse det var noe galt med 😄)