### PR TITLE
Sender et fullverdig content-objekt i responsen ved redirect til custom path

### DIFF
--- a/src/main/resources/lib/headless/guillotine/queries/sitecontent.es6
+++ b/src/main/resources/lib/headless/guillotine/queries/sitecontent.es6
@@ -238,8 +238,10 @@ const getSiteContent = (requestedPathOrId, branch = 'master', time) => {
     // If the content has a custom path, we want to redirect requests from the internal path
     if (shouldRedirectToCustomPath(content, requestedPathOrId, branch)) {
         return {
+            ...content,
             __typename: 'no_nav_navno_InternalLink',
             data: { target: { _path: content.data.customPath } },
+            page: undefined,
         };
     }
 


### PR DESCRIPTION
Hindrer potensielle feil som kom til syne med den nye /shadow route'en i frontend (denne forbigår server-side redirects). Responsen ved redirect til en custompath/kort-url inkluderer ikke alle obligatoriske felter i et content-objekt, som kan forårsake feil i frontend ved lesing av f.eks. _path eller _id

Eks https://www.nav.no/shadow/en/family/single-parents/supplemental-benefit-for-single-parents