### PR TITLE
Fjerner default antall kolonner for flex cols

### DIFF
--- a/src/main/resources/site/layouts/situation-flex-cols/situation-flex-cols-config.ts
+++ b/src/main/resources/site/layouts/situation-flex-cols/situation-flex-cols-config.ts
@@ -21,7 +21,7 @@ export interface SituationFlexColsConfig {
   toggleCopyButton: boolean;
 
   /**
-   * Antall kolonner ved full skjermbredde
+   * Overstyr antall kolonner ved full skjermbredde
    */
   numCols?: number;
 

--- a/src/main/resources/site/layouts/situation-flex-cols/situation-flex-cols.xml
+++ b/src/main/resources/site/layouts/situation-flex-cols/situation-flex-cols.xml
@@ -4,8 +4,7 @@
     <form>
         <mixin name="header-with-anchor"/>
         <input type="Long" name="numCols">
-            <label>Antall kolonner ved full skjermbredde</label>
-            <default>3</default>
+            <label>Overstyr antall kolonner ved full skjermbredde</label>
             <config>
                 <min>1</min>
                 <max>3</max>


### PR DESCRIPTION
Dersom numCols ikke er satt, så vil frontend avgjøre korrekt kolonneantall basert på antall parts. Derfor er dette feltet mer som en overstyring enn tidligere.