### PR TITLE
Optimalisering for content som ikke eksisterer

### DIFF
--- a/src/main/resources/lib/headless/guillotine/queries/sitecontent.es6
+++ b/src/main/resources/lib/headless/guillotine/queries/sitecontent.es6
@@ -91,6 +91,13 @@ const getPublishedVersionTimestamps = (contentRef, branch) => {
 };
 
 const getContent = (contentRef, branch) => {
+    // Do a contentLib lookup first to check if the content exists.
+    // This is much quicker than running a full Guillotine query.
+    const rawContent = runInBranchContext(() => contentLib.get({ key: contentRef }), branch);
+    if (!rawContent) {
+        return null;
+    }
+
     const response = guillotineQuery(
         queryGetContentByRef,
         {


### PR DESCRIPTION
Sjekker om content finnes før guillotine-queriet kjøres. Kutter ned respons-tiden ved 404 med ca 95%. Har sett ganske store spikes i server-load når vi blir pen-testet (de fleste requests gir da 404), denne bør fikse det.