### PR TITLE
content-type-switcher tilgangsstyring

### DIFF
--- a/src/main/resources/admin/widgets/content-type-switcher/content-type-switcher.ts
+++ b/src/main/resources/admin/widgets/content-type-switcher/content-type-switcher.ts
@@ -2,6 +2,7 @@ import contentLib from '/lib/xp/content';
 import portalLib from '/lib/xp/portal';
 import thymeleafLib from '/lib/thymeleaf';
 import { contentTypesInContentSwitcher } from '../../../lib/contenttype-lists';
+import { validateCurrentUserPermissionForContent } from '../../../lib/utils/auth-utils';
 
 const view = resolve('./content-type-switcher.html');
 
@@ -16,6 +17,13 @@ const getAllowedTypes = () => {
 export const get = (req: XP.Request) => {
     const { repositoryId } = req;
     const { contentId } = req.params;
+
+    if (!validateCurrentUserPermissionForContent(contentId, 'PUBLISH')) {
+        return {
+            body: '<widget>Tilgangsfeil - Du må ha publiseringstilgang for å endre innholdstype</widget>',
+            contentType: 'text/html; charset=UTF-8',
+        };
+    }
 
     const model = {
         types: getAllowedTypes(),

--- a/src/main/resources/admin/widgets/content-type-switcher/content-type-switcher.xml
+++ b/src/main/resources/admin/widgets/content-type-switcher/content-type-switcher.xml
@@ -5,6 +5,6 @@
         <interface>contentstudio.contextpanel</interface>
     </interfaces>
     <allow>
-        <principal>role:system.admin</principal>
+        <principal>role:system.authenticated</principal>
     </allow>
 </widget>


### PR DESCRIPTION
Endrer fra å kreve admin-tilgang til kun å kreve innlogget med publiseringstilgang for å bruke content-type-switcher widget'en