### PR TITLE
Fjerner OG-logikk for filtere

### DIFF
--- a/src/main/resources/site/mixins/filter-selector/filter-selector.ts
+++ b/src/main/resources/site/mixins/filter-selector/filter-selector.ts
@@ -4,9 +4,4 @@ export interface FilterSelector {
    * Velg filtre
    */
   filters?: Array<string>;
-
-  /**
-   * Logikk
-   */
-  filterLogic: "or" | "and";
 }

--- a/src/main/resources/site/mixins/filter-selector/filter-selector.xml
+++ b/src/main/resources/site/mixins/filter-selector/filter-selector.xml
@@ -10,15 +10,6 @@
                         <service>filterSelector</service>
                     </config>
                 </input>
-                <input name="filterLogic" type="RadioButton">
-                    <label>Logikk</label>
-                    <occurrences minimum="1" maximum="1"/>
-                    <config>
-                        <option value="or">ELLER</option>
-                        <option value="and">OG</option>
-                    </config>
-                    <default>or</default>
-                </input>
             </items>
         </field-set>
     </form>

--- a/src/main/resources/site/parts/calculator/calculator-part-config.ts
+++ b/src/main/resources/site/parts/calculator/calculator-part-config.ts
@@ -14,9 +14,4 @@ export interface CalculatorPartConfig {
    * Velg filtre
    */
   filters?: Array<string>;
-
-  /**
-   * Logikk
-   */
-  filterLogic: "or" | "and";
 }

--- a/src/main/resources/site/parts/html-area/html-area-part-config.ts
+++ b/src/main/resources/site/parts/html-area/html-area-part-config.ts
@@ -26,11 +26,6 @@ export interface HtmlAreaPartConfig {
   filters?: Array<string>;
 
   /**
-   * Logikk
-   */
-  filterLogic: "or" | "and";
-
-  /**
    * Velg visning
    */
   renderOnAuthState: "always" | "loggedIn" | "loggedOut";


### PR DESCRIPTION
OG-logikk fungerte ikke helt slik vi tenkte for Foreldrepenger. Vi har derfor blitt enige om å fjerne den igjen før flere tar den i bruk.