### PR TITLE
Fiks for tomme fragmenter og for area/taxonomy type

### DIFF
--- a/src/main/resources/lib/guillotine/queries/fragments/content-types/contentPageWithSidemenusFragment.graphql
+++ b/src/main/resources/lib/guillotine/queries/fragments/content-types/contentPageWithSidemenusFragment.graphql
@@ -4,6 +4,8 @@
 fragment contentContentPageWithSidemenus on no_nav_navno_ContentPageWithSidemenus {
     dataAsJson
     data {
+        area
+        taxonomy
         languages {
             ...languagesMixin
         }

--- a/src/main/resources/lib/guillotine/queries/fragments/content-types/guidePageFragment.graphql
+++ b/src/main/resources/lib/guillotine/queries/fragments/content-types/guidePageFragment.graphql
@@ -4,6 +4,7 @@
 fragment contentGuidePage on no_nav_navno_GuidePage {
     dataAsJson
     data {
+        area
         languages {
             ...languagesMixin
         }

--- a/src/main/resources/lib/guillotine/queries/fragments/content-types/situationPageFragment.graphql
+++ b/src/main/resources/lib/guillotine/queries/fragments/content-types/situationPageFragment.graphql
@@ -5,6 +5,7 @@
 fragment contentSituationPage on no_nav_navno_SituationPage {
     dataAsJson
     data {
+        area
         languages {
             ...languagesMixin
         }

--- a/src/main/resources/lib/guillotine/queries/fragments/content-types/themedArticlePageFragment.graphql
+++ b/src/main/resources/lib/guillotine/queries/fragments/content-types/themedArticlePageFragment.graphql
@@ -4,6 +4,8 @@
 fragment contentThemedArticlePage on no_nav_navno_ThemedArticlePage {
     dataAsJson
     data {
+        area
+        taxonomy
         languages {
             ...languagesMixin
         }

--- a/src/main/resources/lib/guillotine/queries/fragments/content-types/toolsPageFragment.graphql
+++ b/src/main/resources/lib/guillotine/queries/fragments/content-types/toolsPageFragment.graphql
@@ -4,6 +4,8 @@
 fragment contentToolsPage on no_nav_navno_ToolsPage {
     dataAsJson
     data {
+        area
+        taxonomy
         languages {
             ...languagesMixin
         }

--- a/src/main/resources/lib/guillotine/schema/schema-creation-callbacks.ts
+++ b/src/main/resources/lib/guillotine/schema/schema-creation-callbacks.ts
@@ -28,9 +28,11 @@ import {
 import { macroAlertboxCallback } from './schema-creation-callbacks/macro-alert-box';
 import { richTextCallback } from './schema-creation-callbacks/richtext';
 import { overviewCallback } from './schema-creation-callbacks/overview-callback';
+import { fragmentComponentDataCallback } from './schema-creation-callbacks/fragment-component-data';
 
 export const schemaCreationCallbacks = {
     Attachment: attachmentCallback,
+    FragmentComponentData: fragmentComponentDataCallback,
     media_Code: mediaCodeCallback,
     media_Image: mediaImageCallback,
     no_nav_navno_MainArticle: mainArticleCallback,

--- a/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/fragment-component-data.ts
+++ b/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/fragment-component-data.ts
@@ -1,0 +1,10 @@
+import { CreationCallback } from '../../utils/creation-callback-utils';
+
+export const fragmentComponentDataCallback: CreationCallback = (context, params) => {
+    // fragment id is required in the built-in schema, but may be missing if a fragment is added
+    // in the editor without selecting an actual fragment. Return a dummy id to ensure both the
+    // editor and the graphql schema validator behaves correctly
+    params.fields.id.resolve = (env) => {
+        return env.source.id || 'error-missing-fragment-id';
+    };
+};

--- a/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/page-navigation-menu.ts
+++ b/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/page-navigation-menu.ts
@@ -97,6 +97,10 @@ const getFragmentAnchorLink = (
 ) => {
     const { id } = fragment;
 
+    if (!id) {
+        return null;
+    }
+
     const content = repo.get<Content<'portal:fragment'>>({ key: id });
 
     if (!content) {


### PR DESCRIPTION
- Fikser Graphql-feil ved manglende fragment-id
- Fikser typefeil på taxonomy og area felt dersom disse kun har en verdi satt. Må spesifiseres i graphql-queriet for at disse alltid skal konverteres til arrays.