### PR TITLE
Fikser selector for page-controller i page-templates

### DIFF
--- a/src/main/resources/lib/controllers/page-template-filter.ts
+++ b/src/main/resources/lib/controllers/page-template-filter.ts
@@ -1,0 +1,13 @@
+import portalLib from '/lib/xp/portal';
+import { adminFrontendProxy } from './admin-frontend-proxy';
+
+// For unconfigured page-templates we want to send the request to the standard XP controller
+// in order to show the page-controller selector in the editor
+export const filter = (req: XP.Request, next: any) => {
+    const content = portalLib.getContent();
+    if (content?.type === 'portal:page-template' && !content.page?.descriptor) {
+        return next(req);
+    }
+
+    return adminFrontendProxy(req);
+};

--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -11,6 +11,9 @@
         <mapping controller="/lib/controllers/site-info-controller.js">
             <match>type:'portal:site'</match>
         </mapping>
+        <mapping filter="/lib/controllers/page-template-filter.js">
+            <match>type:'portal:page-template'</match>
+        </mapping>
         <mapping controller="/lib/controllers/admin-frontend-proxy.js">
             <pattern>/.*</pattern>
         </mapping>

--- a/src/main/resources/types/content-types/content-config.d.ts
+++ b/src/main/resources/types/content-types/content-config.d.ts
@@ -76,6 +76,12 @@ export type ContentDataMapper<Type extends ContentDescriptor> = Type extends Cus
           fragment: Component<'part' | 'layout'>;
           data: undefined;
       }
+    : Type extends 'portal:page-template'
+    ? {
+          type: 'portal:page-template';
+          data: { supports?: CustomContentDescriptor | CustomContentDescriptor[] };
+          page: Component<'page'> | EmptyObject;
+      }
     : never;
 
 export type BuiltinContentDescriptor =


### PR DESCRIPTION
Løsningen for å velge page-controller når en oppretter en ny page-template har tydeligvis blitt endret på ett eller annet tidspunkt, og fungerer ikke lengre med oppsettet vårt. Legger på et filter for page-templates som sender requesten for tommer templates til standard XP-controlleren, slik at editoren setter riktig state for å vise page-controller selectoren.