### PR TITLE
Mapper noen media:* til frontend proxy

### DIFF
--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -12,7 +12,7 @@
             <match>type:'portal:site'</match>
         </mapping>
         <mapping controller="/lib/controllers/admin-frontend-proxy.js">
-            <match>type:'^(?!(portal:page-template)|(media:.+)).+'</match>
+            <match>type:'^(?!(portal:page-template)|(media:(document|image|vector|text|video))).+'</match>
         </mapping>
     </mappings>
     <processors>


### PR DESCRIPTION
Document, image, vector, text og video har innebygd preview-visning i Content studio. Resten skal mappes til vår controller (som kun vil vise "ingen forhåndsvisning" for andre media-typer). Skal hindre errors pga manglende page templates