### PR TITLE
Legger ikke-serializable globals inn via setupFiles

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,0 +1,5 @@
+// eslint-disable-next-line no-undef
+// @ts-ignore
+global.Java = {
+    type: () => ({}),
+};

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -78,9 +78,6 @@ export default {
                 serviceSecret: 'dummyToken',
             },
         },
-        Java: {
-            type: () => ({}),
-        },
     },
 
     // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
@@ -148,7 +145,7 @@ export default {
     // runner: "jest-runner",
 
     // The paths to modules that run some code to configure or set up the testing environment before each test
-    // setupFiles: [],
+    setupFiles: ['./jest-setup.ts'],
 
     // A list of paths to modules that run some code to configure or set up the testing framework before each test
     // setupFilesAfterEnv: [],


### PR DESCRIPTION
"globals" config-objektet støtter egentlig kun verdier som er JSON-serializable, altså ikke funksjonsdefinisjoner. Av en eller annen grunn har det fungert allikevel, bortsett fra på Bjørnar sitt system. Forhåpentligvis fungerer det for alle nå :D 