### PR TITLE
Bypass legacy helsesjekk

### DIFF
--- a/src/main/resources/lib/controllers/frontend-proxy.ts
+++ b/src/main/resources/lib/controllers/frontend-proxy.ts
@@ -28,7 +28,7 @@ const errorResponse = (url: string, status: number, message: string) => {
     };
 };
 
-// Prevents outdated health-check from blocking routing to our servers...
+// The legacy health check expects an html-response on /no/person
 const healthCheckDummyResponse = () => {
     return {
         contentType: 'text/html; charset=UTF-8',


### PR DESCRIPTION
Returnerer en dummy html-response på /no/person dersom denne ikke lengre bruker 'dynamic-page' som content-type. Når vi går live med ny forside vil denne endres til en redirect, hvis helsesjekken ikke er oppdatert innen da vil denne PR'en hindre at visse ting feiler. 😄 