### PR TITLE
Håndterer feil fra cache resolver callback

### DIFF
--- a/src/main/resources/services/sitecontent/cache.ts
+++ b/src/main/resources/services/sitecontent/cache.ts
@@ -21,8 +21,13 @@ export const getResponseFromCache = (
 
     try {
         return cache.get(cacheKey, callback);
-    } catch (e) {
+    } catch (e: any) {
         // cache.get throws if callback returns null
-        return null;
+        if (e.message.startsWith('CacheLoader returned null for key')) {
+            return null;
+        }
+
+        // For any other error, throw to the next handler
+        throw e;
     }
 };


### PR DESCRIPTION
Problem i dag: error catch-blokk for sitecontent cache'en spiser feil fra bl.a. guillotine, som fører til at alle errors returnere null/404. Vi vil at errors skal returnere 500-feil, slik at frontend kan servere cachet innhold ved feil.