### PR TITLE
Fikser bugs med referanse-query for macroer

### DIFF
--- a/src/main/resources/lib/utils/htmlarea-utils.ts
+++ b/src/main/resources/lib/utils/htmlarea-utils.ts
@@ -42,13 +42,5 @@ export const findContentsWithHtmlAreaText = (text: string) => {
 };
 
 export const findContentsWithFragmentMacro = (fragmentId: string) => {
-    return findContentsWithHtmlAreaText(`fragmentId=\\"${fragmentId}`);
-};
-
-export const findContentsWithProductCardMacro = (targetPageId: string) => {
-    return findContentsWithHtmlAreaText(`targetPage=\\"${targetPageId}`);
-};
-
-export const findContentsWithPayoutDatesMacro = (payoutDatesId: string) => {
-    return findContentsWithHtmlAreaText(`payoutDates=\\"${payoutDatesId}`);
+    return findContentsWithHtmlAreaText(fragmentId);
 };


### PR DESCRIPTION
Gjelder søk etter referanser for cache-invalidering.

Fjerner søk etter content-id i spesifikke macro-felter, og søker heller etter kun selve id'en, slik at alle id-referanser plukkes opp. Bør være en enklere/mer generell/muligens mer performant løsning, som også fikser noen edge-cases som ikke fungerte med forrige løsning.