### PR TITLE
Åpner for å bruke fleksibel kolonne-layout på Slik gjør du det-sider

### DIFF
--- a/src/main/resources/site/layouts/product-flex-cols/product-flex-cols.xml
+++ b/src/main/resources/site/layouts/product-flex-cols/product-flex-cols.xml
@@ -1,12 +1,13 @@
 <layout>
-    <display-name>Fleksibelt kolonne-layout for produktsider og temasider</display-name>
-    <description>Fleksibel kolonne-layout for produktsider og temasider</description>
+    <display-name>Fleksibelt kolonne-layout for produktsider, temasider og slik gjør du det</display-name>
+    <description>Fleksibel kolonne-layout for produktsider, temasider og slik gjør du det</description>
     <form>
         <mixin name="header-with-anchor"/>
     </form>
     <config>
         <allow-on-content-type>${app}:content-page-with-sidemenus</allow-on-content-type>
         <allow-on-content-type>${app}:themed-article-page</allow-on-content-type>
+        <allow-on-content-type>${app}:guide-page</allow-on-content-type>
         <allow-on-content-type>portal:page-template</allow-on-content-type>
     </config>
     <regions>


### PR DESCRIPTION
Redaktørene trenger å bruke fleksibel kolonne-layout en sjelden gang på "Slik gjør du det"-maler. Så da må vi nesten åpne opp for alle disse malene.