### PR TITLE
Åpne for brukertest på arbeidsgiverforsiden

### DIFF
--- a/src/main/resources/site/parts/frontpage-survey-panel/frontpage-survey-panel.xml
+++ b/src/main/resources/site/parts/frontpage-survey-panel/frontpage-survey-panel.xml
@@ -29,6 +29,7 @@
     </form>
     <config>
         <allow-on-content-type>${app}:front-page</allow-on-content-type>
+        <allow-on-content-type>${app}:dynamic-page</allow-on-content-type>
         <allow-on-content-type>portal:page-template</allow-on-content-type>
     </config>
 </part>


### PR DESCRIPTION
Åpner opp for brukertestpanel på dynamic-page. Ikke helt optimalt, men eneste løsning siden arbeidsgiverforsiden fortsatt bruker denne malen.