### PR TITLE
Setter default repo-id for tasks som håndterer forhåndspublisering/avpublisering

### DIFF
--- a/src/main/resources/tasks/prepublish-cache-wipe/prepublish-cache-wipe.ts
+++ b/src/main/resources/tasks/prepublish-cache-wipe/prepublish-cache-wipe.ts
@@ -1,9 +1,10 @@
 import { PrepublishCacheWipeConfig } from './prepublish-cache-wipe-config';
 import { invalidateCacheForNode } from '../../lib/cache/cache-invalidate';
 import { logger } from '../../lib/utils/logging';
+import { CONTENT_ROOT_REPO_ID } from '../../lib/constants';
 
 export const run = (params: PrepublishCacheWipeConfig) => {
-    const { id, path, repoId } = params;
+    const { id, path, repoId = CONTENT_ROOT_REPO_ID } = params;
     logger.info(`Running task for cache invalidation of prepublished content - ${id} - ${path}`);
 
     invalidateCacheForNode({

--- a/src/main/resources/tasks/prepublish-cache-wipe/prepublish-cache-wipe.xml
+++ b/src/main/resources/tasks/prepublish-cache-wipe/prepublish-cache-wipe.xml
@@ -11,7 +11,7 @@
         </input>
         <input type="TextLine" name="repoId">
             <label>Repo id</label>
-            <occurrences minimum="1" maximum="1"/>
+            <occurrences minimum="0" maximum="1"/>
         </input>
     </form>
 </task>

--- a/src/main/resources/tasks/unpublish-expired-content/unpublish-expired-content.ts
+++ b/src/main/resources/tasks/unpublish-expired-content/unpublish-expired-content.ts
@@ -6,9 +6,10 @@ import { getUnixTimeFromDateTimeString } from '../../lib/utils/nav-utils';
 import { logger } from '../../lib/utils/logging';
 import { getLayersData } from '../../lib/localization/layers-data';
 import { runInLocaleContext } from '../../lib/localization/locale-context';
+import { CONTENT_ROOT_REPO_ID } from '../../lib/constants';
 
 export const run = (params: UnpublishExpiredContentConfig) => {
-    const { id, path, repoId } = params;
+    const { id, path, repoId = CONTENT_ROOT_REPO_ID } = params;
 
     logger.info(`Running task for unpublishing expired content - ${id} - ${path}`);
 

--- a/src/main/resources/tasks/unpublish-expired-content/unpublish-expired-content.xml
+++ b/src/main/resources/tasks/unpublish-expired-content/unpublish-expired-content.xml
@@ -11,7 +11,7 @@
         </input>
         <input type="TextLine" name="repoId">
             <label>Repo id</label>
-            <occurrences minimum="1" maximum="1"/>
+            <occurrences minimum="0" maximum="1"/>
         </input>
     </form>
 </task>


### PR DESCRIPTION
...slik at disse fungerer med eksisterende scheduler jobs som ikke har repoId-feltet satt