### PR TITLE
Workaround for valg av publiseringstidspunkt i versjonshistorikk

### DIFF
--- a/src/main/resources/lib/contenttype-lists.ts
+++ b/src/main/resources/lib/contenttype-lists.ts
@@ -15,17 +15,6 @@ export const legacyPageContentTypes: ContentTypeList = [
     `${APP_DESCRIPTOR}:melding`,
 ];
 
-export const productCardPartContentTypes: ContentTypeList = [
-    `${APP_DESCRIPTOR}:situation-page`,
-    `${APP_DESCRIPTOR}:guide-page`,
-    `${APP_DESCRIPTOR}:themed-article-page`,
-    `${APP_DESCRIPTOR}:content-page-with-sidemenus`,
-    `${APP_DESCRIPTOR}:tools-page`,
-    `${APP_DESCRIPTOR}:overview`,
-    `${APP_DESCRIPTOR}:generic-page`,
-    `${APP_DESCRIPTOR}:current-topic-page`,
-];
-
 export const dynamicPageContentTypes: ContentTypeList = [
     `${APP_DESCRIPTOR}:situation-page`,
     `${APP_DESCRIPTOR}:guide-page`,
@@ -127,4 +116,9 @@ export const contentTypesRenderedByEditorFrontend: ContentTypeList = [
     'portal:page-template',
     'portal:fragment',
     'portal:site',
+];
+
+export const contentTypesWithCustomEditor: ContentTypeList = [
+    `${APP_DESCRIPTOR}:global-value-set`,
+    `${APP_DESCRIPTOR}:global-case-time-set`,
 ];

--- a/src/main/resources/lib/utils/version-utils.ts
+++ b/src/main/resources/lib/utils/version-utils.ts
@@ -1,10 +1,12 @@
 import * as contextLib from '/lib/xp/context';
+import { Content } from '/lib/xp/content';
 import { getRepoConnection } from './repo-connection';
 import { RepoConnection, NodeVersionMetadata } from '/lib/xp/node';
 import { RepoBranch } from '../../types/common';
 import { contentLibGetStandard } from '../time-travel/standard-functions';
 import { logger } from './logging';
 import { getUnixTimeFromDateTimeString } from './datetime-utils';
+import { contentTypesWithCustomEditor } from '../contenttype-lists';
 
 const MAX_VERSIONS_COUNT_TO_RETRIEVE = 1000;
 
@@ -100,6 +102,12 @@ export const getVersionFromTime = ({
     return foundVersion;
 };
 
+// Workaround for content types with a custom editor, which does not update the modifiedTime field
+// in the same way as the Content Studio editor. We always need to include all timestamps for these
+// types.
+const shouldGetModifiedTimestampsOnly = (content: Content | null) =>
+    content ? !contentTypesWithCustomEditor.includes(content.type) : true;
+
 // Used by the version history selector in the frontend
 export const getPublishedVersionTimestamps = (contentRef: string) => {
     const context = contextLib.get();
@@ -108,11 +116,13 @@ export const getPublishedVersionTimestamps = (contentRef: string) => {
         branch: 'master',
     });
 
+    const content = repo.get(contentRef);
+
     const versions = getNodeVersions({
         nodeKey: getNodeKey(contentRef),
         branch: 'master',
         repo,
-        modifiedOnly: true,
+        modifiedOnly: shouldGetModifiedTimestampsOnly(content),
     });
 
     return versions.map((version) => version.timestamp);


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Custom editoren for globale verdier/saksbehandlingstider oppdaterer ikke modifiedTime på samme måte som Content Studio normalt gjør. Dette gjør at publiseringstidspunktene i versjonshistorikk-velgeren ikke inkluderer alle publiseringer. Legger til en workaround som fikser dette for disse innholdstypene

## Testing

Testet lokalt
