### PR TITLE
Henter alltid innhold til fragment-macroer fra master

### DIFF
--- a/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/macro-html-fragment.ts
+++ b/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/macro-html-fragment.ts
@@ -5,6 +5,7 @@ import { CreationCallback } from '../../utils/creation-callback-utils';
 import { getKeyWithoutMacroDescription } from '../../../utils/component-utils';
 import { HtmlAreaPartConfig } from '../../../../site/parts/html-area/html-area-part-config';
 import { logger } from '../../../utils/logging';
+import { runInContext } from '../../../context/run-in-context';
 
 export const macroHtmlFragmentCallback: CreationCallback = (context, params) => {
     params.fields.processedHtml = {
@@ -17,7 +18,7 @@ export const macroHtmlFragmentCallback: CreationCallback = (context, params) => 
 
             const key = getKeyWithoutMacroDescription(fragmentId);
 
-            const content = contentLib.get({ key });
+            const content = runInContext({ branch: 'master' }, () => contentLib.get({ key }));
             if (!content) {
                 logger.critical(
                     `Content not found for fragment in html-fragment macro: ${fragmentId}`,

--- a/src/main/resources/services/htmlFragmentSelector/htmlFragmentSelector.ts
+++ b/src/main/resources/services/htmlFragmentSelector/htmlFragmentSelector.ts
@@ -54,7 +54,7 @@ const selectorHandler = (req: XP.CustomSelectorServiceRequest) => {
     const htmlFragments = contentLib.query({
         ...(query && { query: `displayName LIKE "*${query}*"` }),
         start: 0,
-        count: 10000,
+        count: 1000,
         contentTypes: ['portal:fragment'],
         filters: {
             boolean: {


### PR DESCRIPTION
Dette blir da likt som i servicen for å velge fragment. Legger også inn en advarsel i frontend for når et fragment mangler innhold, slik at det blir tydeligere for redaktørene når et fragment som er i bruk har blitt avpublisert.

