### PR TITLE
Fikser issue med custompaths ved duplisering/publisering

### DIFF
--- a/src/main/resources/lib/paths/custom-paths/custom-path-event-listeners.ts
+++ b/src/main/resources/lib/paths/custom-paths/custom-path-event-listeners.ts
@@ -45,7 +45,7 @@ const removeCustomPathOnDuplicate = (event: EnonicEvent) => {
             return;
         }
 
-        logger.info(`Removing custom path from duplicated content ${id}`);
+        logger.info(`Removing custom path from duplicated content ${id} in repo ${repo}`);
 
         removeCustomPath(id, repoConnection);
     });
@@ -75,7 +75,7 @@ const removeInvalidCustomPathOnPublish = (event: EnonicEvent) => {
             return;
         }
 
-        logger.info(`Removing invalid custom path on published content ${id}`);
+        logger.info(`Removing invalid custom path on published content ${id} in repo ${repo}`);
 
         removeCustomPath(id, repoConnection);
 


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Sørger for at alle customPaths fjernes når et innhold med children dupliseres
- Fikser eventhandler som fjerner ugyldige customPaths ved publisering

