### PR TITLE
Fikser fallback for chat contact-info part når ingen id er spesifisert

### DIFF
--- a/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/part-contact-option-chat.ts
+++ b/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/part-contact-option-chat.ts
@@ -3,14 +3,19 @@ import graphQlLib from '/lib/graphql';
 import { CreationCallback } from '../../utils/creation-callback-utils';
 import { CONTENT_LOCALE_DEFAULT } from '../../../constants';
 
-const getChatContactInformation = (contactContentId: string, lang?: string) => {
+const getChatContactInformation = (contactContentId?: string, lang?: string) => {
     const queryResults = contentLib.query({
         count: 1,
         contentTypes: ['no.nav.navno:contact-information'],
+        sort: 'createdTime ASC',
         filters: {
-            ids: {
-                values: [contactContentId],
-            },
+            // If no contact info was specified, we will get the oldest
+            // matching language version instead
+            ...(contactContentId && {
+                ids: {
+                    values: [contactContentId],
+                },
+            }),
             boolean: {
                 must: [
                     {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Fikser bug som ble innført ved nylig omskrivning av diverse contact-info funksjonalitet. Sørger for at delt kontakt-info for chat benyttes også når ingen kontakt-info er spesifisert.