### PR TITLE
Legger til ekstra log-info. Bytter endepunkt for norg til prod-fss.

### DIFF
--- a/src/main/resources/lib/constants.ts
+++ b/src/main/resources/lib/constants.ts
@@ -22,7 +22,7 @@ const revalidatorProxyOrigin = {
 }[env];
 
 const norgOfficeOrigin = {
-    p: 'https://norg2.intern.nav.no/norg2/api/v2/navlokalkontor?statusFilter=AKTIV',
+    p: 'https://norg2.prod-fss-pub.nais.io/norg2/api/v2/navlokalkontor?statusFilter=AKTIV',
     dev: 'https://norg2.dev-fss-pub.nais.io/norg2/api/v2/navlokalkontor?statusFilter=AKTIV',
     q6: 'https://norg2.dev-fss-pub.nais.io/norg2/api/v2/navlokalkontor?statusFilter=AKTIV',
     localhost: 'https://norg2.dev-fss-pub.nais.io/norg2/api/v2/navlokalkontor?statusFilter=AKTIV',

--- a/src/main/resources/lib/officeBranch/update.ts
+++ b/src/main/resources/lib/officeBranch/update.ts
@@ -35,7 +35,9 @@ export const fetchAllOfficeBranchesFromNorg = () => {
             return null;
         }
     } catch (e) {
-        logger.error(`OfficeImporting: Exception from norg2 request: ${e}`);
+        logger.error(
+            `OfficeImporting: Exception from norg2 request: ${e}. Fetching from ${URLS.NORG_OFFICE_ORIGIN}.`
+        );
         return null;
     }
 };


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Forbedrer logging ved feil fra NORG-import. Forsøker fss-endepunkt fremfor intern.nav.no.