### PR TITLE
Forbedrer sitecontent cache-key

### DIFF
--- a/src/main/resources/services/sitecontent/cache.ts
+++ b/src/main/resources/services/sitecontent/cache.ts
@@ -1,26 +1,23 @@
 import cacheLib from '/lib/cache';
+import { SiteContentParams } from './sitecontent';
 
 const oneDay = 60 * 60 * 24;
 
 const cache = cacheLib.newCache({ size: 10000, expire: oneDay });
 
-const getCacheKey = (contentId: string, cacheVersionKey: string) =>
-    `${contentId}_${cacheVersionKey}`;
+const getCacheKeyForRequest = ({ id, cacheKey, locale, branch, preview }: SiteContentParams) =>
+    `${id}_${cacheKey}_${locale}_${branch}_${preview}`;
 
-export const getResponseFromCache = (
-    contentId: string,
-    callback: () => any,
-    cacheVersionKey?: string
-) => {
-    // If no version key is provided, do not get from cache
-    if (!cacheVersionKey) {
+export const getResponseFromCache = (reqParams: SiteContentParams, callback: () => any) => {
+    // If no cache key is provided, do not get from cache
+    if (!reqParams.cacheKey) {
         return callback();
     }
 
-    const cacheKey = getCacheKey(contentId, cacheVersionKey);
+    const requestSpecificCacheKey = getCacheKeyForRequest(reqParams);
 
     try {
-        return cache.get(cacheKey, callback);
+        return cache.get(requestSpecificCacheKey, callback);
     } catch (e: any) {
         // cache.get throws if callback returns null
         if (e.message.startsWith('CacheLoader returned null for key')) {

--- a/src/main/resources/services/sitecontent/sitecontent.ts
+++ b/src/main/resources/services/sitecontent/sitecontent.ts
@@ -3,6 +3,15 @@ import { getResponseFromCache } from './cache';
 import { generateSitecontentResponse } from './generate-response';
 import { logger } from '../../lib/utils/logging';
 import { validateServiceSecretHeader } from '../../lib/utils/auth-utils';
+import { RepoBranch } from '../../types/common';
+
+export type SiteContentParams = {
+    id: string;
+    branch?: RepoBranch;
+    preview?: 'true';
+    cacheKey?: string;
+    locale: string;
+};
 
 export const get = (req: XP.Request) => {
     if (!validateServiceSecretHeader(req)) {
@@ -16,7 +25,13 @@ export const get = (req: XP.Request) => {
     }
 
     // id can be a content UUID, or a content path, ie. /www.nav.no/no/person
-    const { id: idOrPath, branch = 'master', preview, cacheKey, locale } = req.params;
+    // TODO: validate parameters in a cleaner way
+    const {
+        id: idOrPath,
+        branch = 'master',
+        preview,
+        locale,
+    } = req.params as unknown as Partial<SiteContentParams>;
 
     if (!idOrPath) {
         return {
@@ -39,16 +54,13 @@ export const get = (req: XP.Request) => {
     }
 
     try {
-        const content = getResponseFromCache(
-            idOrPath,
-            () =>
-                generateSitecontentResponse({
-                    idOrPathRequested: idOrPath,
-                    localeRequested: locale,
-                    branch,
-                    isPreview: preview === 'true',
-                }),
-            cacheKey
+        const content = getResponseFromCache(req.params as SiteContentParams, () =>
+            generateSitecontentResponse({
+                idOrPathRequested: idOrPath,
+                localeRequested: locale,
+                branch,
+                isPreview: preview === 'true',
+            })
         );
 
         if (!content) {


### PR DESCRIPTION
Inkluderer alle parametre i cache-key'en, slik at f.eks locale eller preview parametre resulterer i forskjellige cache-entries. Fikser bl.a. en bug der innhold som kun skal vises som preview ble cachet som en vanlig respons.