### PR TITLE
Invaliderer cache for sider med chat-part når chat kontakt-info endres

### DIFF
--- a/src/main/resources/lib/cache/find-references.ts
+++ b/src/main/resources/lib/cache/find-references.ts
@@ -179,7 +179,7 @@ const getChatContactInfoReferences = (content: Content) => {
     }).hits;
 
     logger.info(
-        `Updated chat module ${content._path} for ${pagesWithDefaultChatInfo.length} references`
+        `Found ${pagesWithDefaultChatInfo.length} references for chat contact info ${content._path}`
     );
 
     return pagesWithDefaultChatInfo;


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Sørger for at cache invalideres for sider med chat kontakt-info,  også når denne ikke har satt en eksplisitt referanse til et contact-info objekt