### PR TITLE
Forbedrer publisering av kontorer endret etter NORG-import

### DIFF
--- a/src/main/resources/lib/officeBranch/update.ts
+++ b/src/main/resources/lib/officeBranch/update.ts
@@ -60,13 +60,10 @@ const isPathOccupiedByAlienContent = (name: string) => {
 const deleteContent = (name: string) => {
     const office = contentLib.get({ key: `${basePath}/${name}` });
 
-    if (!office) {
+    if (!office || office.type !== officeBranchContentType) {
         return null;
     }
 
-    return null;
-
-    /*
     const officeId = office._id;
 
     // Move the content to a temp path first, as deletion does not seem to be a synchronous operation
@@ -83,8 +80,6 @@ const deleteContent = (name: string) => {
     });
 
     return officeId;
-
-    */
 };
 
 const getOfficeBranchLanguage = (office: any) => {

--- a/src/main/resources/lib/officeBranch/update.ts
+++ b/src/main/resources/lib/officeBranch/update.ts
@@ -58,11 +58,13 @@ const isPathOccupiedByAlienContent = (name: string) => {
 
 // Delete content from XP
 const deleteContent = (name: string) => {
-    const office = contentLib.get({ key: name });
+    const office = contentLib.get({ key: `${basePath}/${name}` });
 
     if (!office) {
         return null;
     }
+
+    const officeId = office._id;
 
     // Move the content to a temp path first, as deletion does not seem to be a synchronous operation
     // We want to free up the source path immediately
@@ -72,9 +74,12 @@ const deleteContent = (name: string) => {
         source: office._path,
         target: `${office._name}-delete`,
     });
+
     contentLib.delete({
         key: office._id,
     });
+
+    return officeId;
 };
 
 const getOfficeBranchLanguage = (office: any) => {
@@ -196,10 +201,14 @@ const deleteStaleOfficesFromXP = (
     const deletedIds: string[] = [];
     existingOfficesInXP.forEach((existingOffice) => {
         const { enhetNr, navn } = existingOffice?.data;
+        let deletedId;
 
         if (!validOfficeEnhetNrs.includes(enhetNr)) {
-            deleteContent(commonLib.sanitize(navn));
-            deletedIds.push(existingOffice._id);
+            deletedId = deleteContent(commonLib.sanitize(navn));
+        }
+
+        if (deletedId) {
+            deletedIds.push(deletedId);
         }
     });
 

--- a/src/main/resources/lib/officeBranch/update.ts
+++ b/src/main/resources/lib/officeBranch/update.ts
@@ -112,7 +112,7 @@ const moveOfficeToNewName = (existingOffice: Content<OfficeBranchDescriptor>, ne
 
         // Create a redirect from the old path
 
-        contentLib.create<'no.nav.navno:internal-link'>({
+        const internalLink = contentLib.create<'no.nav.navno:internal-link'>({
             name: currentName,
             parentPath: basePath,
             displayName: `${existingOffice.displayName} (redirect til ${newOffice.navn})`,
@@ -122,6 +122,13 @@ const moveOfficeToNewName = (existingOffice: Content<OfficeBranchDescriptor>, ne
                 permanentRedirect: false,
                 redirectSubpaths: false,
             },
+        });
+
+        contentLib.publish({
+            keys: [internalLink._id],
+            sourceBranch: 'draft',
+            targetBranch: 'master',
+            includeDependencies: false,
         });
     } catch (e) {
         logger.critical(

--- a/src/main/resources/lib/officeBranch/update.ts
+++ b/src/main/resources/lib/officeBranch/update.ts
@@ -64,6 +64,9 @@ const deleteContent = (name: string) => {
         return null;
     }
 
+    return null;
+
+    /*
     const officeId = office._id;
 
     // Move the content to a temp path first, as deletion does not seem to be a synchronous operation
@@ -80,6 +83,8 @@ const deleteContent = (name: string) => {
     });
 
     return officeId;
+
+    */
 };
 
 const getOfficeBranchLanguage = (office: any) => {

--- a/src/main/resources/lib/officeBranch/update.ts
+++ b/src/main/resources/lib/officeBranch/update.ts
@@ -68,7 +68,7 @@ const deleteContent = (name: string) => {
 
     // Move the content to a temp path first, as deletion does not seem to be a synchronous operation
     // We want to free up the source path immediately
-    contentLib.unpublish({ keys: [office._id] });
+    contentLib.unpublish({ keys: [officeId] });
 
     contentLib.move({
         source: office._path,
@@ -76,7 +76,7 @@ const deleteContent = (name: string) => {
     });
 
     contentLib.delete({
-        key: office._id,
+        key: officeId,
     });
 
     return officeId;


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Publiserer konkrete office-id'er fremfor hele pathen. Unngår problemet når et element i en undermappe ikke er committed i XP (feks noen som jobber på redaksjonelt kontorinnhold).

Fikser feil ved sletting av kontor i XP som ikke lenger finnes i NORG.

## Testing
Testet lokalt og på q6.
