### PR TITLE
Tillate flere samtidige kategorier i skjemadetaljer

### DIFF
--- a/src/main/resources/lib/guillotine/queries/fragments/components/parts/partFormDetails.graphql
+++ b/src/main/resources/lib/guillotine/queries/fragments/components/parts/partFormDetails.graphql
@@ -4,4 +4,8 @@ fragment partComponentFormDetails on Part_no_nav_navno_form_details {
     targetFormDetails {
         ...formDetailsMixin
     }
+    showTitle
+    showIngress
+    showApplications
+    showAddendums
 }

--- a/src/main/resources/lib/guillotine/queries/fragments/content-types/formDetailsFragment.graphql
+++ b/src/main/resources/lib/guillotine/queries/fragments/content-types/formDetailsFragment.graphql
@@ -22,10 +22,12 @@ fragment contentFormDetails on no_nav_navno_FormDetails {
                     type
                 }
             }
-        }
-        addendums {
-            label
-            url
+            addendum {
+                variations {
+                    label
+                    url
+                }
+            }
         }
     }
 }

--- a/src/main/resources/lib/guillotine/queries/fragments/content-types/formDetailsFragment.graphql
+++ b/src/main/resources/lib/guillotine/queries/fragments/content-types/formDetailsFragment.graphql
@@ -13,7 +13,6 @@ fragment contentFormDetails on no_nav_navno_FormDetails {
                 variations {
                     label
                     url
-                    type
                 }
             }
             complaint {
@@ -23,13 +22,10 @@ fragment contentFormDetails on no_nav_navno_FormDetails {
                     type
                 }
             }
-            addendum {
-                variations {
-                    label
-                    url
-                    type
-                }
-            }
+        }
+        addendums {
+            label
+            url
         }
     }
 }

--- a/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/form-details.ts
+++ b/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/form-details.ts
@@ -7,7 +7,6 @@ export const formDetailsCallback: CreationCallback = (context, params) => {
     params.fields.targetFormDetails = {
         type: graphQlLib.reference('no_nav_navno_FormDetails'),
         resolve: (env) => {
-            log.info(env.source.targetFormDetails);
             return contentLib.get({ key: env.source.targetFormDetails });
         },
     };

--- a/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/form-details.ts
+++ b/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/form-details.ts
@@ -7,6 +7,7 @@ export const formDetailsCallback: CreationCallback = (context, params) => {
     params.fields.targetFormDetails = {
         type: graphQlLib.reference('no_nav_navno_FormDetails'),
         resolve: (env) => {
+            log.info(env.source.targetFormDetails);
             return contentLib.get({ key: env.source.targetFormDetails });
         },
     };

--- a/src/main/resources/site/content-types/form-details/form-details.ts
+++ b/src/main/resources/site/content-types/form-details/form-details.ts
@@ -18,7 +18,7 @@ export interface FormDetails {
   /**
    * Variasjoner
    */
-  formType:
+  formType: Array<
     | {
         /**
          * Selected
@@ -73,25 +73,32 @@ export interface FormDetails {
             type: "complaint" | "appeal";
           }>;
         };
-      };
+      }
+    | {
+        /**
+         * Selected
+         */
+        _selected: "addendum";
 
-  /**
-   * Ettersendelser
-   */
-  addendums?: Array<{
-    /**
-     * Knappetekst
-     */
-    label?: string;
+        /**
+         * Ettersendelse
+         */
+        addendum: {
+          /**
+           * Ettersendelsesvariasjoner
+           */
+          variations?: Array<{
+            /**
+             * Knappetekst
+             */
+            label?: string;
 
-    /**
-     * URL til skjema
-     */
-    url?: string;
-
-    /**
-     * Type ettersendelse
-     */
-    type: "addendum_digital" | "addendum_paper";
-  }>;
+            /**
+             * URL til skjema
+             */
+            url?: string;
+          }>;
+        };
+      }
+  >;
 }

--- a/src/main/resources/site/content-types/form-details/form-details.ts
+++ b/src/main/resources/site/content-types/form-details/form-details.ts
@@ -40,11 +40,6 @@ export interface FormDetails {
              * URL til skjema
              */
             url?: string;
-
-            /**
-             * Søknads- eller skjematype
-             */
-            type: "digital" | "paper";
           }>;
         };
       }
@@ -78,36 +73,25 @@ export interface FormDetails {
             type: "complaint" | "appeal";
           }>;
         };
-      }
-    | {
-        /**
-         * Selected
-         */
-        _selected: "addendum";
-
-        /**
-         * Ettersendelse
-         */
-        addendum: {
-          /**
-           * Ettersendelsesvariasjoner
-           */
-          variations?: Array<{
-            /**
-             * Knappetekst
-             */
-            label?: string;
-
-            /**
-             * URL til skjema
-             */
-            url?: string;
-
-            /**
-             * Type ettersendelse
-             */
-            type: "addendum_digital" | "addendum_paper";
-          }>;
-        };
       };
+
+  /**
+   * Ettersendelser
+   */
+  addendums?: Array<{
+    /**
+     * Knappetekst
+     */
+    label?: string;
+
+    /**
+     * URL til skjema
+     */
+    url?: string;
+
+    /**
+     * Type ettersendelse
+     */
+    type: "addendum_digital" | "addendum_paper";
+  }>;
 }

--- a/src/main/resources/site/content-types/form-details/form-details.ts
+++ b/src/main/resources/site/content-types/form-details/form-details.ts
@@ -53,9 +53,7 @@ export interface FormDetails {
          * Klage- og ankevariasjoner
          */
         complaint: {
-          /**
-           * Klage- og ankevariasjoner
-           */
+
           variations?: Array<{
             /**
              * Knappetekst

--- a/src/main/resources/site/content-types/form-details/form-details.ts
+++ b/src/main/resources/site/content-types/form-details/form-details.ts
@@ -84,9 +84,7 @@ export interface FormDetails {
          * Ettersendelse
          */
         addendum: {
-          /**
-           * Ettersendelsesvariasjoner
-           */
+
           variations?: Array<{
             /**
              * Knappetekst

--- a/src/main/resources/site/content-types/form-details/form-details.xml
+++ b/src/main/resources/site/content-types/form-details/form-details.xml
@@ -21,7 +21,7 @@
                 </input>
                 <option-set name="formType">
                     <label>Variasjoner</label>
-                    <occurrences minimum="1" maximum="1"/>
+                    <occurrences minimum="1" maximum="0"/>
                     <help-text>Velg hva slags type variasjon du vil lage - søknad, klage eller ettersendelse. For kun redaksjonell tekst kan du la være å fylle inn felter for søknadsvariasjonen.</help-text>
                     <options minimum="1" maximum="1">
                         <option name="application">
@@ -72,21 +72,26 @@
                                 </item-set>
                             </items>
                         </option>
+                        <option name="addendum">
+                            <label>Ettersendelse</label>
+                            <items>
+                                <item-set name="variations">
+                                    <label>Ettersendelsesvariasjoner</label>
+                                    <occurrences minimum="0" maximum="0"/>
+                                    <items>
+                                        <input name="label" type="TextLine">
+                                            <label>Knappetekst</label>
+                                            <help-text>Bør være kort. Alternativt flere korte ord.</help-text>
+                                        </input>
+                                        <input name="url" type="TextLine">
+                                            <label>URL til skjema</label>
+                                        </input>
+                                    </items>
+                                </item-set>
+                            </items>
+                        </option>
                     </options>
                 </option-set>
-                <item-set name="addendums">
-                    <label>Ettersendelser</label>
-                    <occurrences minimum="0" maximum="0"/>
-                    <items>
-                        <input name="label" type="TextLine">
-                            <label>Knappetekst</label>
-                            <help-text>Bør være kort. Alternativt flere korte ord.</help-text>
-                        </input>
-                        <input name="url" type="TextLine">
-                            <label>URL til skjema</label>
-                        </input>
-                    </items>
-                </item-set>
             </items>
         </field-set>
     </form>

--- a/src/main/resources/site/content-types/form-details/form-details.xml
+++ b/src/main/resources/site/content-types/form-details/form-details.xml
@@ -22,7 +22,7 @@
                 <option-set name="formType">
                     <label>Variasjoner</label>
                     <occurrences minimum="1" maximum="1"/>
-                    <help-text>Velg hva slags type variasjon du vil lage - søknad, klage eller ettersendelse.</help-text>
+                    <help-text>Velg hva slags type variasjon du vil lage - søknad, klage eller ettersendelse. For kun redaksjonell tekst kan du la være å fylle inn felter for søknadsvariasjonen.</help-text>
                     <options minimum="1" maximum="1">
                         <option name="application">
                             <label>Søknad / skjema</label>
@@ -37,18 +37,6 @@
                                         </input>
                                         <input name="url" type="TextLine">
                                             <label>URL til skjema</label>
-                                        </input>
-                                        <input type="ComboBox" name="type">
-                                            <label>Søknads- eller skjematype</label>
-                                            <occurrences minimum="1" maximum="1"/> 
-                                            <config>
-                                                <option value="digital"> 
-                                                    Digital
-                                                </option>
-                                                <option value="paper"> 
-                                                    Papir
-                                                </option>
-                                            </config>
                                         </input>
                                     </items>
                                 </item-set>
@@ -71,7 +59,7 @@
                                         <input type="ComboBox" name="type">
                                             <label>Klage- eller anketype</label>
                                             <occurrences minimum="1" maximum="1"/> 
-                                            <config>  
+                                            <config>
                                                 <option value="complaint"> 
                                                     Klage
                                                 </option>
@@ -84,38 +72,21 @@
                                 </item-set>
                             </items>
                         </option>
-                        <option name="addendum">
-                            <label>Ettersendelse</label>
-                            <items>
-                                <item-set name="variations">
-                                    <label>Ettersendelsesvariasjoner</label>
-                                    <occurrences minimum="0" maximum="0"/>
-                                    <items>
-                                        <input name="label" type="TextLine">
-                                            <label>Knappetekst</label>
-                                            <help-text>Bør være kort. Alternativt flere korte ord.</help-text>
-                                        </input>
-                                        <input name="url" type="TextLine">
-                                            <label>URL til skjema</label>
-                                        </input>
-                                        <input type="ComboBox" name="type">
-                                            <label>Type ettersendelse</label>
-                                            <occurrences minimum="1" maximum="1"/> 
-                                            <config>  
-                                                <option value="addendum_digital"> 
-                                                    Ettersendelse digital
-                                                </option>
-                                                <option value="addendum_paper"> 
-                                                    Ettersendelse papir
-                                                </option>
-                                            </config>
-                                        </input>
-                                    </items>
-                                </item-set>
-                            </items>
-                        </option>
                     </options>
                 </option-set>
+                <item-set name="addendums">
+                    <label>Ettersendelser</label>
+                    <occurrences minimum="0" maximum="0"/>
+                    <items>
+                        <input name="label" type="TextLine">
+                            <label>Knappetekst</label>
+                            <help-text>Bør være kort. Alternativt flere korte ord.</help-text>
+                        </input>
+                        <input name="url" type="TextLine">
+                            <label>URL til skjema</label>
+                        </input>
+                    </items>
+                </item-set>
             </items>
         </field-set>
     </form>

--- a/src/main/resources/site/content-types/form-details/form-details.xml
+++ b/src/main/resources/site/content-types/form-details/form-details.xml
@@ -46,7 +46,6 @@
                             <label>Klage- og ankevariasjoner</label>
                             <items>
                                 <item-set name="variations">
-                                    <label>Klage- og ankevariasjoner</label>
                                     <occurrences minimum="0" maximum="0"/>
                                     <items>
                                         <input name="label" type="TextLine">
@@ -76,7 +75,6 @@
                             <label>Ettersendelse</label>
                             <items>
                                 <item-set name="variations">
-                                    <label>Ettersendelsesvariasjoner</label>
                                     <occurrences minimum="0" maximum="0"/>
                                     <items>
                                         <input name="label" type="TextLine">

--- a/src/main/resources/site/parts/form-details/form-details-part-config.ts
+++ b/src/main/resources/site/parts/form-details/form-details-part-config.ts
@@ -4,4 +4,24 @@ export interface FormDetailsPartConfig {
    * Velg skjemadetalj
    */
   targetFormDetails: string;
+
+  /**
+   * Vis tittel
+   */
+  showTitle: boolean;
+
+  /**
+   * Vis ingress
+   */
+  showIngress: boolean;
+
+  /**
+   * Vis inngang til søknad
+   */
+  showApplications: boolean;
+
+  /**
+   * Vis inngang til ettersendelse
+   */
+  showAddendums: boolean;
 }

--- a/src/main/resources/site/parts/form-details/form-details.xml
+++ b/src/main/resources/site/parts/form-details/form-details.xml
@@ -10,6 +10,27 @@
                 <service>selectedFormDetails</service>
             </config>
         </input>
+        <field-set>
+            <label>Tilpass visning</label>
+            <items>
+                <input name="showTitle" type="CheckBox">
+                    <label>Vis tittel</label>
+                    <default>checked</default>
+                </input>
+                <input name="showIngress" type="CheckBox">
+                    <label>Vis ingress</label>
+                    <default>checked</default>
+                </input>
+                <input name="showApplications" type="CheckBox">
+                    <label>Vis inngang til søknad</label>
+                    <default>checked</default>
+                </input>
+                <input name="showAddendums" type="CheckBox">
+                    <label>Vis inngang til ettersendelse</label>
+                    <default>checked</default>
+                </input>
+            </items>
+        </field-set>
     </form>
     <config>
         <allow-on-content-type>${app}:content-page-with-sidemenus</allow-on-content-type>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Åpner opp for å legge til flere kategorier samtidig (Søknad, klage/anke og ettersendelse) i samme skjemdetalj.
- Kan styre hvilke detaljer som skal vises når man setter inn en part for skjemadetaljen.
- Fjerner type (digltalt / papir) siden dette ikke er behov for når vi får mellomsteg på plass.

## Testing
Testes i q6 av Janne og Terje