### PR TITLE
Fjerner restriksjon på host i validering av skjema-urler på skjemadetaljer

### DIFF
--- a/src/main/resources/lib/controllers/form-details-controller.ts
+++ b/src/main/resources/lib/controllers/form-details-controller.ts
@@ -18,13 +18,14 @@ const migrateOldUrlField = (req: XP.Request) => {
         const { _selected } = formTypeField;
         const variations = forceArray((formTypeField as any)[_selected].variations);
         return variations.forEach((variation) => {
-            if (!variation.url) {
+            const { url } = variation;
+            if (!url) {
                 return;
             }
 
             variation.link = {
                 _selected: 'external',
-                external: { url: variation.url },
+                external: { url: url.toLowerCase().startsWith('http') ? url : `https://${url}` },
             };
 
             variation.url = null;

--- a/src/main/resources/site/mixins/form-details-link/form-details-link.xml
+++ b/src/main/resources/site/mixins/form-details-link/form-details-link.xml
@@ -12,7 +12,6 @@
                             <label>Velg mellomsteg</label>
                             <occurrences minimum="1" maximum="1"/>
                             <config>
-                                <allowPath>/www.nav.no/*</allowPath>
                                 <allowContentType>no.nav.navno:form-intermediate-step</allowContentType>
                                 <showStatus>true</showStatus>
                             </config>

--- a/src/main/resources/site/mixins/form-details-link/form-details-link.xml
+++ b/src/main/resources/site/mixins/form-details-link/form-details-link.xml
@@ -27,7 +27,7 @@
                             <default>https://www.nav.no/</default>
                             <occurrences minimum="1" maximum="1"/>
                             <config>
-                                <regexp>^https:\/\/([a-z0-9_\-.]*\.)?nav\.no($|\/).*</regexp>
+                                <regexp>^https?:\/\/.*</regexp>
                             </config>
                         </input>
                     </items>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Tillater alle hosts, ikke bare nav.no, ettersom vi noen ganger lenker til skjemaer på andre hosts.
- Fikser eksterne url'er som ikke har http-prefix