### PR TITLE
Støtter mulighet for batch-migrering til layers av forhåndsdefinert innhold

### DIFF
--- a/src/main/resources/lib/localization/layers-migration/migration-batch-job.ts
+++ b/src/main/resources/lib/localization/layers-migration/migration-batch-job.ts
@@ -23,8 +23,8 @@ type SourceAndTargetContent = { sourceContent: Content; targetBaseContent: Conte
 
 type LayerMigrationBatchJobResult = {
     status: string;
-    params: Params;
-    result: ReturnType<typeof migrateContentBatchToLayers>;
+    params: any;
+    result: any;
 };
 
 export type LayersMigrationResultCache = cacheLib.Cache & {


### PR DESCRIPTION
Skal kun brukes for fragmenter. Kommer til å mate den fra et regneark som redaktørene har fått for å fylle ut språkreferanser.