### PR TITLE
Setter en separat origin for preview fra XP-frontend

### DIFF
--- a/src/main/resources/lib/constants.ts
+++ b/src/main/resources/lib/constants.ts
@@ -17,6 +17,13 @@ const frontendOrigins: EnvRecord = {
     localhost: 'http://localhost:3000',
 };
 
+const frontendPreviewOrigins: EnvRecord = {
+    p: 'https://www.nav.no',
+    dev: 'https://www-editor.ekstern.dev.nav.no',
+    q6: 'https://www-editor-2.ekstern.dev.nav.no',
+    localhost: 'http://localhost:3000',
+};
+
 const revalidatorProxyOrigins: EnvRecord = {
     p: 'https://www.nav.no/revalidator-proxy',
     dev: 'https://nav-enonicxp-frontend-revalidator-proxy.intern.dev.nav.no',
@@ -31,9 +38,17 @@ const norgOfficeApiUrls: EnvRecord = {
     localhost: 'https://norg2.dev-fss-pub.nais.io/norg2/api/v2/navlokalkontor?statusFilter=AKTIV',
 };
 
+const xpOrigins: EnvRecord = {
+    p: 'https://www.nav.no',
+    dev: 'https://www.dev.nav.no',
+    q6: 'https://www-q6.nav.no',
+    localhost: 'http://localhost:8080',
+};
+
 export const URLS = Object.freeze({
     FRONTEND_ORIGIN: frontendOrigins[env],
-    XP_ORIGIN: app.config.xpOrigin,
+    FRONTEND_PREVIEW_ORIGIN: frontendPreviewOrigins[env],
+    XP_ORIGIN: xpOrigins[env],
     REVALIDATOR_PROXY_ORIGIN: revalidatorProxyOrigins[env],
     PORTAL_ADMIN_ORIGIN: portalAdminOrigins[env],
     NORG_OFFICE_API_URL: norgOfficeApiUrls[env],

--- a/src/main/resources/lib/controllers/component-preview-controller.ts
+++ b/src/main/resources/lib/controllers/component-preview-controller.ts
@@ -64,7 +64,7 @@ export const componentPreviewController = (_: XP.Request) => {
 
     try {
         const componentHtml = httpClient.request({
-            url: `${URLS.FRONTEND_ORIGIN}/api/component-preview`,
+            url: `${URLS.FRONTEND_PREVIEW_ORIGIN}/api/component-preview`,
             method: 'POST',
             body: JSON.stringify({ props: componentProps }),
             contentType: 'application/json',

--- a/src/main/resources/lib/controllers/frontend-proxy.ts
+++ b/src/main/resources/lib/controllers/frontend-proxy.ts
@@ -50,6 +50,7 @@ export const frontendProxy = (req: XP.Request, path?: string) => {
     // Ensures our legacy health-check still works after the old /no/person page is removed
     // TODO: remove this asap after the health-check has been updated
     if (req.mode === 'live' && req.url.endsWith('/no/person')) {
+        logger.info('Is the old health check still in use? (Yes it is!)');
         return healthCheckDummyResponse();
     }
 

--- a/src/main/resources/lib/controllers/frontend-proxy.ts
+++ b/src/main/resources/lib/controllers/frontend-proxy.ts
@@ -55,8 +55,8 @@ export const frontendProxy = (req: XP.Request, path?: string) => {
 
     const pathStartIndex = req.rawPath.indexOf(req.branch) + req.branch.length;
     const contentPath = path || stripPathPrefix(req.rawPath.slice(pathStartIndex));
-    const frontendUrl = `${URLS.FRONTEND_ORIGIN}${
-        req.branch === 'draft' ? '/draft' : ''
+    const frontendUrl = `${
+        req.branch === 'draft' ? `${URLS.FRONTEND_PREVIEW_ORIGIN}/draft` : URLS.FRONTEND_ORIGIN
     }${contentPath}`;
 
     try {

--- a/src/main/resources/lib/controllers/frontend-proxy.ts
+++ b/src/main/resources/lib/controllers/frontend-proxy.ts
@@ -4,7 +4,7 @@ import { logger } from '../utils/logging';
 import { getLocaleFromRepoId } from '../localization/layers-data';
 import { stripPathPrefix } from '../paths/path-utils';
 
-const loopbackCheckParam = 'fromXp';
+const LOOKBACK_CHECK_PARAM = 'fromXp';
 
 const errorResponse = (url: string, status: number, message: string) => {
     const msg = `Failed to fetch from frontend: ${url} - ${status}: ${message}`;
@@ -19,15 +19,6 @@ const errorResponse = (url: string, status: number, message: string) => {
     };
 };
 
-// The legacy health check expects an html-response on /no/person
-// "Nyheter" must be part of the response!
-const healthCheckDummyResponse = () => {
-    return {
-        contentType: 'text/html; charset=UTF-8',
-        body: '<html lang="no"><head><meta charset="utf-8"><title>Nav.no</title></head><body><div>Hei, jeg er en ex-forside. Her var det blant annet Nyheter og nyheter.</div></body></html>',
-    };
-};
-
 // Proxy requests to XP to the frontend. Normally this will only be used in the portal-admin
 // content studio previews and from the error controller
 export const frontendProxy = (req: XP.Request, path?: string) => {
@@ -37,7 +28,7 @@ export const frontendProxy = (req: XP.Request, path?: string) => {
         };
     }
 
-    const isLoopback = req.params[loopbackCheckParam];
+    const isLoopback = req.params[LOOKBACK_CHECK_PARAM];
     if (isLoopback) {
         logger.warning(`Loopback to XP detected from path ${req.rawPath}`);
         return {
@@ -45,13 +36,6 @@ export const frontendProxy = (req: XP.Request, path?: string) => {
             body: `<div>Error: request to frontend looped back to XP</div>`,
             status: 200,
         };
-    }
-
-    // Ensures our legacy health-check still works after the old /no/person page is removed
-    // TODO: remove this asap after the health-check has been updated
-    if (req.mode === 'live' && req.url.endsWith('/no/person')) {
-        logger.info('Is the old health check still in use? (Yes it is!)');
-        return healthCheckDummyResponse();
     }
 
     const pathStartIndex = req.rawPath.indexOf(req.branch) + req.branch.length;
@@ -71,7 +55,7 @@ export const frontendProxy = (req: XP.Request, path?: string) => {
             followRedirects: false,
             queryParams: {
                 ...req.params,
-                [loopbackCheckParam]: 'true',
+                [LOOKBACK_CHECK_PARAM]: 'true',
                 mode: req.mode,
                 locale: getLocaleFromRepoId(req.repositoryId),
             },

--- a/src/main/resources/services/sitecontent/generate-response.ts
+++ b/src/main/resources/services/sitecontent/generate-response.ts
@@ -21,6 +21,7 @@ import { contentTypesRenderedByEditorFrontend } from '../../lib/contenttype-list
 import { stringArrayToSet } from '../../lib/utils/array-utils';
 
 import { resolveLegacyContentRedirects } from './resolve-legacy-content-redirects';
+import { getContentFromCustomPath } from '../../lib/paths/custom-paths/custom-path-utils';
 
 const contentTypesForGuillotineQuery = stringArrayToSet(contentTypesRenderedByEditorFrontend);
 
@@ -117,7 +118,12 @@ const resolveContentStudioRequest = (
     const localeActual = isValidLocale(locale) ? locale : getLayersData().defaultLocale;
 
     return runInLocaleContext({ locale: localeActual, branch }, () => {
-        const content = contentLib.get({ key: idOrPathRequested });
+        const content =
+            contentLib.get({ key: idOrPathRequested }) ||
+            getContentFromCustomPath(idOrPathRequested).find(
+                // Allow requests to a customPath from CS, as long as it is unique
+                (contentWithCustomPath, _, array) => array.length === 1
+            );
         if (!content) {
             return null;
         }

--- a/src/main/resources/services/sitecontent/resolve-legacy-content-redirects.ts
+++ b/src/main/resources/services/sitecontent/resolve-legacy-content-redirects.ts
@@ -1,7 +1,8 @@
-import { transformToRedirectResponse } from './resolve-redirects';
 import * as contentLib from '/lib/xp/content';
+import { Content } from '/lib/xp/content';
+import { transformToRedirectResponse } from './resolve-redirects';
 
-export const resolveLegacyContentRedirects = (content: contentLib.Content) => {
+export const resolveLegacyContentRedirects = (content: Content) => {
     // Note: There are legacy office pages still in effect that also have the
     // content type office-information. As long as the enhetNr doesn't match up
     // with any office-branch content, the next function will pass by these

--- a/src/main/resources/services/sitecontent/resolve-legacy-content-redirects.ts
+++ b/src/main/resources/services/sitecontent/resolve-legacy-content-redirects.ts
@@ -1,13 +1,7 @@
 import { transformToRedirectResponse } from './resolve-redirects';
 import * as contentLib from '/lib/xp/content';
 
-const legacyContentToRedirect = ['no.nav.navno:office-information'];
-
 export const resolveLegacyContentRedirects = (content: contentLib.Content) => {
-    if (!legacyContentToRedirect.includes(content.type)) {
-        return;
-    }
-
     // Note: There are legacy office pages still in effect that also have the
     // content type office-information. As long as the enhetNr doesn't match up
     // with any office-branch content, the next function will pass by these
@@ -32,7 +26,7 @@ export const resolveLegacyContentRedirects = (content: contentLib.Content) => {
         });
 
         if (foundOfficeContent.hits.length === 0) {
-            return;
+            return null;
         }
 
         // Try and use the new office branch name, but fall back to the old name if it
@@ -47,5 +41,5 @@ export const resolveLegacyContentRedirects = (content: contentLib.Content) => {
         });
     }
 
-    return;
+    return null;
 };


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Preview for draft-branchen hentes nå fra en separat instans med ekstern.dev ingress, slik at assets fra denne kan lastes av redaktører som ikke benytter VPN. Se også https://github.com/navikt/nav-enonicxp-frontend/pull/1357
- Setter XP-origin i kode fremfor å hente fra server config
- Fikser navigering til customPaths fra previewet