### PR TITLE
Setter forms taxonomy på alle guide-page entries til oversiktssider

### DIFF
--- a/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/forms-overview-data-callback.ts
+++ b/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/forms-overview-data-callback.ts
@@ -52,6 +52,12 @@ const transformToListItem = (content: ContentWithFormDetails): FormDetailsListIt
     const title = content.data.title || content.displayName;
     const sortTitle = content.data.sortTitle || title;
 
+    const taxonomy = forceArray(content.data.taxonomy);
+
+    if (content.type === 'no.nav.navno:guide-page') {
+        taxonomy.push('forms');
+    }
+
     return {
         title,
         sortTitle,
@@ -59,7 +65,7 @@ const transformToListItem = (content: ContentWithFormDetails): FormDetailsListIt
         formDetailsPaths: formDetailsContent.map((formDetails) => formDetails._path),
         illustration: content.data.illustration,
         area: forceArray(content.data.area),
-        taxonomy: forceArray(content.data.taxonomy),
+        taxonomy,
     };
 };
 

--- a/src/main/resources/lib/product-utils/productList.ts
+++ b/src/main/resources/lib/product-utils/productList.ts
@@ -132,9 +132,15 @@ const getProductDetails = (
 const buildCommonProductData = (product: ContentWithProductDetails) => {
     const data = product.data as ContentWithProductDetailsData;
     const fullTitle = data.title || product.displayName;
+    const taxonomy = forceArray(data.taxonomy);
+
+    if (product.type === 'no.nav.navno:guide-page') {
+        taxonomy.push('forms');
+    }
 
     return {
         ...data,
+        taxonomy,
         _id: product._id,
         type: product.type,
         path: product._path,

--- a/src/main/resources/site/mixins/product-data/product-data.ts
+++ b/src/main/resources/site/mixins/product-data/product-data.ts
@@ -28,7 +28,7 @@ export interface ProductData {
   /**
    * Kategori
    */
-  taxonomy?: Array<"assistive_tools" | "followup" | "benefits" | "measures" | "service" | "rights" | "for_employers" | "for_providers" | "for_municipality" | "for_event_organizers" | "for_health_service">;
+  taxonomy?: Array<"assistive_tools" | "followup" | "benefits" | "measures" | "service" | "rights" | "for_employers" | "for_providers" | "for_municipality" | "for_event_organizers" | "for_health_service" | "forms">;
 
   /**
    * Områdekategori

--- a/src/main/resources/site/mixins/taxonomy/taxonomy.ts
+++ b/src/main/resources/site/mixins/taxonomy/taxonomy.ts
@@ -3,5 +3,5 @@ export interface Taxonomy {
   /**
    * Kategori
    */
-  taxonomy?: Array<"assistive_tools" | "followup" | "benefits" | "measures" | "service" | "rights" | "for_employers" | "for_providers" | "for_municipality" | "for_event_organizers" | "for_health_service">;
+  taxonomy?: Array<"assistive_tools" | "followup" | "benefits" | "measures" | "service" | "rights" | "for_employers" | "for_providers" | "for_municipality" | "for_event_organizers" | "for_health_service" | "forms">;
 }

--- a/src/main/resources/site/mixins/taxonomy/taxonomy.xml
+++ b/src/main/resources/site/mixins/taxonomy/taxonomy.xml
@@ -3,7 +3,7 @@
     <form>
         <input name="taxonomy" type="ComboBox">
             <label>Kategori</label>
-            <occurrences minimum="0" maximum="8"/>
+            <occurrences minimum="0" maximum="0"/>
             <config>
                 <option value="assistive_tools">Hjelpemiddel</option>
                 <option value="followup">Oppfølging</option>
@@ -16,6 +16,7 @@
                 <option value="for_municipality">For kommunen</option>
                 <option value="for_event_organizers">For tiltaksarrangører</option>
                 <option value="for_health_service">For leger og andre behandlere</option>
+                <option value="forms">Skjema</option>
             </config>
         </input>
     </form>


### PR DESCRIPTION
…slik at vi slipper spesialhåndtering av dette i frontend.

Litt copy-paste kode her foreløpig. Tar en runde med refaktorering når skjemaoversikten er spikret.