### PR TITLE
Fikse manglende duplikatsjekk korturl

### DIFF
--- a/src/main/resources/services/customPathSelector/customPathSelector.ts
+++ b/src/main/resources/services/customPathSelector/customPathSelector.ts
@@ -104,7 +104,7 @@ const getResult = ({
     // Also check draft content for custom paths to catch any content
     // that hasn't been published yet (ie. not yet in master)
     const redirectDraftContent = runInContext({ branch: 'draft' }, () => {
-        const existingContentWithSuggestedPath = contentLib.query({
+        const existingHits = contentLib.query({
             start: 0,
             count: 1,
             filters: {
@@ -113,7 +113,15 @@ const getResult = ({
                 },
             },
         }).hits;
-        return existingContentWithSuggestedPath[0];
+
+        if (!existingHits[0]) {
+            return null;
+        }
+
+        const currentContent = portalLib.getContent();
+        // Don't report back on duplicate custom path if the match is the same
+        // content as we're currently editing.
+        return existingHits[0]._id === currentContent._id ? null : existingHits[0];
     });
 
     if (redirectDraftContent && redirectDraftContent.type !== 'base:folder') {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Duplikatsjekk av customPath slår ikke ut dersom innholdsobjektene ikke er publisert til master, men kun finnes i draft.
Denne fiksen utvider sjekken til å gjøre en query på customPath for innhold som også ligger i draft.

Tar også hensyn til at falske positiver kan skje ved match på den innholdstypen som faktisk redigeres.

## Testing

Testes i Q6.

## Dette trenger jeg å få et ekstra blikk på
Sjekk måten queryen gjøres på. Burde ikke skape mye ekstra last, og customPath settes jo ikke veldig ofte, men kan føre til litt mere ventetid.
