### PR TITLE
Tillater skjemadetaljer i legacy artikkelmal

### DIFF
--- a/src/main/resources/services/selectedFormDetails/selectedFormDetails.ts
+++ b/src/main/resources/services/selectedFormDetails/selectedFormDetails.ts
@@ -43,7 +43,8 @@ const getPreselectedFormIds = () => {
     if (
         !(
             currentContent.type === 'no.nav.navno:content-page-with-sidemenus' ||
-            currentContent.type === 'no.nav.navno:guide-page'
+            currentContent.type === 'no.nav.navno:guide-page' ||
+            currentContent.type === 'no.nav.navno:main-article'
         )
     ) {
         return [];

--- a/src/main/resources/site/content-types/main-article/main-article.ts
+++ b/src/main/resources/site/content-types/main-article/main-article.ts
@@ -176,6 +176,11 @@ export interface MainArticle {
   };
 
   /**
+   * Velg alle detaljer som skal brukes på denne siden
+   */
+  formDetailsTargets?: Array<string>;
+
+  /**
    * Del på sosiale medier
    */
   social?: Array<"twitter" | "facebook" | "linkedin">;

--- a/src/main/resources/site/content-types/main-article/main-article.xml
+++ b/src/main/resources/site/content-types/main-article/main-article.xml
@@ -99,6 +99,7 @@
                 </input>
             </items>
         </item-set>
+        <mixin name="form-details-selector"/>
         <field-set>
             <label>Sosiale medier</label>
             <items>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Åpner opp for at man kan velge skjemadetaljer som skal brukes i en legacy artikkelmal, samt at tjenesten som viser aktuelle skjemadetaljer også aksepterer innholdstype main-article.

## Testing
Testes i Q6