### PR TITLE
Støtter Frida-macro som knapp i tillegg til vanlig lenke

### DIFF
--- a/src/main/resources/lib/guillotine/queries/fragments/richText/macrosFragment.graphql
+++ b/src/main/resources/lib/guillotine/queries/fragments/richText/macrosFragment.graphql
@@ -30,6 +30,7 @@ fragment macros on Macro {
         }
         chatbot_link {
             text
+            presentation
         }
         chevron_link_external {
             text

--- a/src/main/resources/site/macros/chatbot-link/chatbot-link-config.ts
+++ b/src/main/resources/site/macros/chatbot-link/chatbot-link-config.ts
@@ -4,4 +4,9 @@ export interface ChatbotLinkConfig {
    * Lenke-tekst
    */
   text: string;
+
+  /**
+   * Vis lenken som
+   */
+  presentation: "link" | "button";
 }

--- a/src/main/resources/site/macros/chatbot-link/chatbot-link.xml
+++ b/src/main/resources/site/macros/chatbot-link/chatbot-link.xml
@@ -5,5 +5,14 @@
             <label>Lenke-tekst</label>
             <occurrences minimum="1" maximum="1"/>
         </input>
+        <input name="presentation" type="RadioButton">
+            <label>Vis lenken som</label>
+            <occurrences minimum="1" maximum="1"/>
+            <config>
+                <option value="link">Lenke</option>  
+                <option value="button">Knapp</option>
+            </config>
+            <default>link</default>
+        </input>
     </form>
 </macro>


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Innstilling for å velge om Chatbot-macro skal vises som sekundærknapp eller lenke.

## Testing
Testes i dev av Olav.