### PR TITLE
Støtter legacy språkvelger på skjemaoversikt

### DIFF
--- a/src/main/resources/site/content-types/forms-overview/forms-overview.ts
+++ b/src/main/resources/site/content-types/forms-overview/forms-overview.ts
@@ -149,4 +149,9 @@ export interface FormsOverview {
    * Skal ikke vises i søk
    */
   noindex: boolean;
+
+  /**
+   * Legg til andre språkversjoner
+   */
+  languages?: Array<string>;
 }

--- a/src/main/resources/site/content-types/forms-overview/forms-overview.xml
+++ b/src/main/resources/site/content-types/forms-overview/forms-overview.xml
@@ -127,5 +127,6 @@
                 </input>
             </items>
         </field-set>
+        <mixin name="languages-legacy"/>
     </form>
 </content-type>

--- a/src/main/resources/site/mixins/languages-legacy/languages-legacy.xml
+++ b/src/main/resources/site/mixins/languages-legacy/languages-legacy.xml
@@ -23,6 +23,7 @@
                         <allowContentType>${app}:area-page</allowContentType>
                         <allowContentType>${app}:front-page</allowContentType>
                         <allowContentType>${app}:generic-page</allowContentType>
+                        <allowContentType>${app}:external-link</allowContentType>
                         <showStatus>true</showStatus>
                     </config>
                 </input>


### PR DESCRIPTION
Må ha denne inntil videre for å lenge til gammel skjemaveiviser på engelsk i språkvelgeren