### PR TITLE
ProductList: Gjør duplikatsjekk bare mot productDetailsPath

### DIFF
--- a/src/main/resources/lib/product-utils/productList.ts
+++ b/src/main/resources/lib/product-utils/productList.ts
@@ -281,8 +281,11 @@ export const getProductDataForOverviewPage = (
         }, [])
         .sort(sortFunc);
 
-    return removeDuplicates(
-        productDataList,
-        (a, b) => a.sortTitle === b.sortTitle && a.productDetailsPath === b.productDetailsPath
-    );
+    // Check for duplicates in other languages than no
+    return language === 'no' ?
+        productDataList :
+        removeDuplicates(
+            productDataList,
+            (a, b) => a.productDetailsPath === b.productDetailsPath
+        );
 };


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Endret filtrering av duplikater til produktoversikter:
Sjekker bare når språk ikke er bokmål og da bare etter path (ikke sortTitle)

## Testing
Vanskelig å teste skikkelig da problemet med duplikater er mest synlig i prod.
Testet lokalt og da var det to av listene på nynorsk (satser og utbetalingstider) som korrekt mistet et duplikat.
