### PR TITLE
Pruner og sorterer lister for nyheter på presse landingsside

### DIFF
--- a/src/main/resources/lib/guillotine/queries/fragments/content-types/pressLandingPageFragment.graphql
+++ b/src/main/resources/lib/guillotine/queries/fragments/content-types/pressLandingPageFragment.graphql
@@ -20,7 +20,5 @@ fragment contentPressLandingPage on no_nav_navno_PressLandingPage {
             ...contentContentList
         }
         moreNewsUrl
-        maxNewsCount
-        maxShortcutsCount
     }
 }

--- a/src/main/resources/lib/guillotine/schema/schema-creation-callbacks.ts
+++ b/src/main/resources/lib/guillotine/schema/schema-creation-callbacks.ts
@@ -97,7 +97,6 @@ export const schemaCreationCallbacks: { [key: string]: CreationCallback } = {
     no_nav_navno_GenericPage_Audience: audienceCallback,
     no_nav_navno_ContentPageWithSidemenus_Audience: audienceCallback,
     no_nav_navno_ThemedArticlePage_Audience: audienceCallback,
-    no_nav_navno_PressLandingPage_Audience: audienceCallback,
     no_nav_navno_ToolsPage_Audience: audienceCallback,
     no_nav_navno_GuidePage_Audience: audienceCallback,
 };

--- a/src/main/resources/lib/guillotine/schema/schema-creation-callbacks.ts
+++ b/src/main/resources/lib/guillotine/schema/schema-creation-callbacks.ts
@@ -41,6 +41,7 @@ import { microCardTargetPageCallback } from './schema-creation-callbacks/microca
 import { createOpeningHoursFields } from './schema-creation-callbacks/common/opening-hours-mixin';
 import { formsOverviewDataCallback } from './schema-creation-callbacks/forms-overview-data-callback';
 import { audienceCallback } from './schema-creation-callbacks/common/audience-mixin';
+import { pressLandingPageDataCallback } from './schema-creation-callbacks/press-landing-page-data';
 
 export const schemaCreationCallbacks: { [key: string]: CreationCallback } = {
     Attachment: attachmentCallback,
@@ -65,6 +66,7 @@ export const schemaCreationCallbacks: { [key: string]: CreationCallback } = {
     no_nav_navno_GlobalValueSet: globalValueSetCallback,
     no_nav_navno_GlobalCaseTimeSet: globalCaseTimeSetCallback,
     no_nav_navno_Calculator_GlobalValue: globalValueCalculatorConfigCallback,
+    no_nav_navno_PressLandingPage_Data: pressLandingPageDataCallback,
     Part_no_nav_navno_areapage_situation_card: areapageSituationCardPartCallback,
     Part_no_nav_navno_dynamic_news_list_ContentList: contentListCallback(
         'target',

--- a/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/press-landing-page-data.ts
+++ b/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/press-landing-page-data.ts
@@ -1,0 +1,11 @@
+import { CreationCallback } from '../../utils/creation-callback-utils';
+import { contentListResolver } from './common/content-list-resolver';
+
+export const pressLandingPageDataCallback: CreationCallback = (context, params) => {
+    params.fields.shortcuts.resolve = contentListResolver('shortcuts', 'maxShortcutsCount');
+    params.fields.pressNews.resolve = contentListResolver(
+        'pressNews',
+        'maxNewsCount',
+        'publish.from'
+    );
+};

--- a/src/main/resources/site/processors/page-template-processor.ts
+++ b/src/main/resources/site/processors/page-template-processor.ts
@@ -10,7 +10,6 @@ const contentTypesToMigrate: { [key in ContentDescriptor]?: true } = {
     'no.nav.navno:area-page': true,
     'no.nav.navno:current-topic-page': true,
     'no.nav.navno:front-page': true,
-    'no.nav.navno:press-landing-page': true,
     'no.nav.navno:situation-page': true,
     'no.nav.navno:tools-page': true,
     'no.nav.navno:generic-page': true,


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Sorterer nyhetsliste på presseside etter siste publiseringsdato
- Pruner listene på presseside