### PR TITLE
Endrer dev origins til portal-admin-*.oera.no

### DIFF
--- a/config/dev/com.enonic.xp.web.vhost.cfg
+++ b/config/dev/com.enonic.xp.web.vhost.cfg
@@ -6,6 +6,12 @@ mapping.public.source = /
 mapping.public.target = /site/default/master/www.nav.no/
 mapping.public.idProvider.adfs = default
 
+# Services
+mapping.services.host = portal-admin-dev.oera.no
+mapping.services.source = /_
+mapping.services.target = /site/default/master/_
+mapping.services.idProvider.system = default
+
 # Requests with no site prefix comes from the archive preview
 mapping.archive.host = portal-admin-dev.oera.no
 mapping.archive.source = /admin/site/inline/default/draft/

--- a/config/q6/com.enonic.xp.web.vhost.cfg
+++ b/config/q6/com.enonic.xp.web.vhost.cfg
@@ -6,6 +6,12 @@ mapping.public.source = /
 mapping.public.target = /site/default/master/www.nav.no/
 mapping.public.idProvider.adfs = default
 
+# Services
+mapping.services.host = portal-admin-q6.oera.no
+mapping.services.source = /_
+mapping.services.target = /site/default/master/_
+mapping.services.idProvider.system = default
+
 # Requests with no site prefix comes from the archive preview
 mapping.archive.host = portal-admin-q6.oera.no
 mapping.archive.source = /admin/site/inline/default/draft/

--- a/src/main/resources/lib/constants.ts
+++ b/src/main/resources/lib/constants.ts
@@ -33,8 +33,8 @@ const norgOfficeApiUrls: EnvRecord = {
 
 const xpOrigins: EnvRecord = {
     p: 'https://www.nav.no',
-    dev: 'https://www.dev.nav.no',
-    q6: 'https://www-q6.nav.no',
+    dev: 'https://portal-admin-dev.oera.no',
+    q6: 'https://portal-admin-q6.oera.no',
     localhost: 'http://localhost:8080',
 };
 


### PR DESCRIPTION
SSL cert for www.dev.nav.no er utløpt, så det domenet funker ikke så bra akkurat nå. Tror vi uansett kan klare oss med kun portal-admin-* domenene for dev, så endrer begge test-miljøene til å benytte disse for eksterne tjenester.