### PR TITLE
Begrenser bruk av kontordetalj-part

### DIFF
--- a/src/main/resources/site/content-types/content-page-with-sidemenus/content-page-with-sidemenus.ts
+++ b/src/main/resources/site/content-types/content-page-with-sidemenus/content-page-with-sidemenus.ts
@@ -72,12 +72,12 @@ export interface ContentPageWithSidemenus {
   /**
    * Kategori
    */
-  taxonomy?: Array<"insurance" | "measures" | "service" | "rights" | "form" | "assistive_tools" | "benefits" | "employee_benefits" | "refund" | "for_providers">;
+  taxonomy?: Array<"insurance" | "measures" | "service" | "rights" | "assistive_tools" | "benefits" | "employee_benefits" | "refund">;
 
   /**
    * Områdekategori
    */
-  area: Array<"work" | "family" | "accessibility" | "pension" | "social_counselling" | "other" | "health" | "recruitment" | "inclusion" | "downsizing">;
+  area: Array<"health" | "other" | "work" | "family" | "accessibility" | "pension" | "social_counselling" | "inclusion" | "downsizing" | "recruitment">;
 
   /**
    * Velg piktogram

--- a/src/main/resources/site/content-types/current-topic-page/current-topic-page.ts
+++ b/src/main/resources/site/content-types/current-topic-page/current-topic-page.ts
@@ -62,7 +62,7 @@ export interface CurrentTopicPage {
   /**
    * Områdekategori
    */
-  area: Array<"work" | "family" | "accessibility" | "pension" | "social_counselling" | "other" | "health" | "recruitment" | "inclusion" | "downsizing">;
+  area: Array<"health" | "other" | "work" | "family" | "accessibility" | "pension" | "social_counselling" | "inclusion" | "downsizing" | "recruitment">;
 
   /**
    * Videresend alle besøk til annen url:

--- a/src/main/resources/site/content-types/guide-page/guide-page.ts
+++ b/src/main/resources/site/content-types/guide-page/guide-page.ts
@@ -77,7 +77,7 @@ export interface GuidePage {
   /**
    * Områdekategori
    */
-  area: Array<"work" | "family" | "accessibility" | "pension" | "social_counselling" | "other" | "health" | "recruitment" | "inclusion" | "downsizing">;
+  area: Array<"health" | "other" | "work" | "family" | "accessibility" | "pension" | "social_counselling" | "inclusion" | "downsizing" | "recruitment">;
 
   /**
    * Velg piktogram

--- a/src/main/resources/site/content-types/situation-page/situation-page.ts
+++ b/src/main/resources/site/content-types/situation-page/situation-page.ts
@@ -72,7 +72,7 @@ export interface SituationPage {
   /**
    * Områdekategori
    */
-  area: Array<"work" | "family" | "accessibility" | "pension" | "social_counselling" | "other" | "health" | "recruitment" | "inclusion" | "downsizing">;
+  area: Array<"health" | "other" | "work" | "family" | "accessibility" | "pension" | "social_counselling" | "inclusion" | "downsizing" | "recruitment">;
 
   /**
    * Velg piktogram

--- a/src/main/resources/site/content-types/themed-article-page/themed-article-page.ts
+++ b/src/main/resources/site/content-types/themed-article-page/themed-article-page.ts
@@ -82,7 +82,7 @@ export interface ThemedArticlePage {
   /**
    * Områdekategori
    */
-  area: Array<"work" | "family" | "accessibility" | "pension" | "social_counselling" | "other" | "health" | "recruitment" | "inclusion" | "downsizing">;
+  area: Array<"health" | "other" | "work" | "family" | "accessibility" | "pension" | "social_counselling" | "inclusion" | "downsizing" | "recruitment">;
 
   /**
    * Velg piktogram

--- a/src/main/resources/site/content-types/tools-page/tools-page.ts
+++ b/src/main/resources/site/content-types/tools-page/tools-page.ts
@@ -77,7 +77,7 @@ export interface ToolsPage {
   /**
    * Områdekategori
    */
-  area: Array<"work" | "family" | "accessibility" | "pension" | "social_counselling" | "other" | "health" | "recruitment" | "inclusion" | "downsizing">;
+  area: Array<"health" | "other" | "work" | "family" | "accessibility" | "pension" | "social_counselling" | "inclusion" | "downsizing" | "recruitment">;
 
   /**
    * Velg piktogram

--- a/src/main/resources/site/parts/office-editorial-detail/office-editorial-detail.xml
+++ b/src/main/resources/site/parts/office-editorial-detail/office-editorial-detail.xml
@@ -13,4 +13,7 @@
             </config>
         </input>
     </form>
+    <config>
+        <allow-on-content-type>${app}:office-editorial-page</allow-on-content-type>
+    </config>
 </part>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Kontordetaljer skal kun brukes på redaksjonell kontorside og ikke på andre sider. Da vil siden krasje. Denne PR'en legger på en begrensning på hvilke innholdstyper parten kan brukes på.

Tar også inn endel autogenererte typer som ikke har blitt committet tidligere i forbindelse med en eller annen endring.

## Testing
Testes i q6
