### PR TITLE
Forbedrer referanse-søk

### DIFF
--- a/src/main/resources/lib/cache/cache-invalidate.ts
+++ b/src/main/resources/lib/cache/cache-invalidate.ts
@@ -16,7 +16,6 @@ import { getLayersData } from '../localization/layers-data';
 import { isContentLocalized } from '../localization/locale-utils';
 import { removeDuplicates } from '../utils/array-utils';
 import { getPublicPath } from '../paths/public-path';
-import { CONTENT_LOCALE_DEFAULT } from '../constants';
 
 export const CACHE_INVALIDATE_EVENT_NAME = 'invalidate-cache';
 
@@ -24,46 +23,24 @@ const REFERENCE_SEARCH_TIMEOUT_MS = 10000;
 
 const getPaths = (contents: Content[], locale: string) =>
     contents.reduce<string[]>((acc, content) => {
-        if (!isPublicRenderedType(content)) {
-            return acc;
-        }
-
-        acc.push(getPublicPath(content, locale));
-
-        // Always include the path for the default locale as well, to be on the safe side :)
-        if (locale !== CONTENT_LOCALE_DEFAULT) {
-            acc.push(getPublicPath(content, CONTENT_LOCALE_DEFAULT));
+        if (isPublicRenderedType(content)) {
+            acc.push(getPublicPath(content, locale));
         }
 
         return acc;
     }, []);
 
-const resolveReferencePaths = (id: string, eventType: string, locale: string) => {
+const resolveReferencePaths = (id: string, eventType: string) => {
     // If the content was deleted, we must check in the draft branch for references
     const branch = eventType === 'node.deleted' ? 'draft' : 'master';
 
-    const { defaultLocale, locales } = getLayersData();
+    const { locales } = getLayersData();
 
     const deadline = Date.now() + REFERENCE_SEARCH_TIMEOUT_MS;
 
-    const contentToInvalidate = findReferences({ id, branch, deadline });
-    if (!contentToInvalidate) {
-        return null;
-    }
-
-    const pathsToInvalidate = getPaths(contentToInvalidate, locale);
-
-    // If the locale is not the default, we're done. Otherwise, we need to check if any of the
-    // references found are also referenced in the child layers
-    if (locale !== defaultLocale) {
-        return removeDuplicates(pathsToInvalidate);
-    }
+    const pathsToInvalidate: string[] = [];
 
     const success = locales.every((locale) => {
-        if (locale === defaultLocale) {
-            return true;
-        }
-
         const references = runInLocaleContext({ locale }, () =>
             findReferences({ id, branch, deadline })
         );
@@ -92,7 +69,7 @@ const resolveReferencesAndInvalidateFrontend = ({
 
     runInLocaleContext({ branch: 'master', locale }, () => {
         const eventId = generateCacheEventId(node, timestamp);
-        const pathsToInvalidate = resolveReferencePaths(node.id, eventType, locale);
+        const pathsToInvalidate = resolveReferencePaths(node.id, eventType);
 
         if (!pathsToInvalidate) {
             logger.warning(`Resolving paths for references failed for eventId ${eventId}`);

--- a/src/main/resources/lib/cache/find-references.ts
+++ b/src/main/resources/lib/cache/find-references.ts
@@ -24,18 +24,17 @@ type ContentWithOverviewPages = Content<(typeof contentTypesWithProductDetails)[
 const isTypeWithOverviewPages = (content: Content): content is ContentWithOverviewPages =>
     typesWithOverviewPages[content.type];
 
-// Search string-fields for a content id. Handles ids set with custom selectors
-// or "references" set programmatically, which does not generate true references
-// in the database index
+// Search all fields for a content id string. Handles ids set with custom selectors, macros or
+// "references" set programmatically, which are not indexed as references in the database
 const getStringTypeReferences = (contentId: string) => {
     const references = batchedContentQuery({
         start: 0,
         count: 10000,
-        query: `fulltext('*', '"${contentId}"')`,
+        query: `fulltext('components.part.config.*,components.layout.config.*,data.*', '"${contentId}"')`,
     }).hits;
 
     logger.info(
-        `Found ${references.length} pages with string-references to content id ${contentId}`
+        `Found ${references.length} pages with string references to content id ${contentId}`
     );
 
     return references;

--- a/src/main/resources/lib/cache/find-references.ts
+++ b/src/main/resources/lib/cache/find-references.ts
@@ -1,8 +1,6 @@
 import * as contentLib from '/lib/xp/content';
 import { Content } from '/lib/xp/content';
-import { findContentsWithHtmlAreaText } from '../utils/htmlarea-utils';
-import { getGlobalValueCalcUsage } from '../global-values/global-value-utils';
-import { forceArray, stringArrayToSet } from '../utils/array-utils';
+import { stringArrayToSet } from '../utils/array-utils';
 import { runInContext } from '../context/run-in-context';
 import {
     typesWithDeepReferences as _typesWithDeepReferences,
@@ -10,10 +8,9 @@ import {
 } from '../contenttype-lists';
 import { RepoBranch } from '../../types/common';
 import { logger } from '../utils/logging';
-import { isGlobalValueSetType } from '../global-values/types';
-import { getProductDetailsUsage } from '../product-utils/productDetails';
 import { getParentPath } from '../paths/path-utils';
 import { getAudience } from '../utils/audience';
+import { batchedContentQuery } from '../utils/batched-query';
 
 type ReferencesMap = Record<string, Content>;
 
@@ -29,31 +26,15 @@ const isTypeWithOverviewPages = (content: Content): content is ContentWithOvervi
 
 // Search html-area fields for a content id. Handles references via macros, which does not generate
 // explicit references
-const getHtmlAreaReferences = (content: Content) => {
-    const references = findContentsWithHtmlAreaText(content._id);
+const getStringTypeReferences = (content: Content) => {
+    const references = batchedContentQuery({
+        start: 0,
+        count: 10000,
+        query: `fulltext('*', '"${content._id}"')`,
+    }).hits;
 
     logger.info(
         `Found ${references.length} pages with htmlarea-references to content id ${content._id}`
-    );
-
-    return references;
-};
-
-// Global values used in calculators are selected with a custom selector, and does not generate
-// explicit references
-const getGlobalValueCalculatorReferences = (content: Content) => {
-    if (!isGlobalValueSetType(content)) {
-        return [];
-    }
-
-    const references = forceArray(content.data?.valueItems)
-        .map((item) => {
-            return getGlobalValueCalcUsage(item.key);
-        })
-        .flat();
-
-    logger.info(
-        `Found ${references.length} pages with references to global value id ${content._id}`
     );
 
     return references;
@@ -135,21 +116,6 @@ const getFormDetailsReferences = (content: Content) => {
     return relevantFormsOverviewPages;
 };
 
-// Product details are selected with a custom selector, and does not generate explicit references
-const getProductDetailsReferences = (content: Content) => {
-    if (content.type !== 'no.nav.navno:product-details') {
-        return [];
-    }
-
-    const references = getProductDetailsUsage(content);
-
-    logger.info(
-        `Found ${references.length} pages with references to product details id ${content._id}`
-    );
-
-    return references;
-};
-
 // Editorial pages are merged into office-branch-pages, which in turn is cached.
 // Therefore, any changes to a editorial page must invalidate all office-branch-page cache.
 const getOfficeBranchPagesIfEditorial = (content: Content) => {
@@ -176,34 +142,6 @@ const getOfficeBranchPagesIfEditorial = (content: Content) => {
     }).hits;
 
     return officeBranches;
-};
-
-// AreaPage references to Situation pages are set programatically, which does
-// not seem to generate dependencies in XP. We need to handle this ourselves.
-const getSituationAreaPageReferences = (content: Content) => {
-    if (content.type !== 'no.nav.navno:situation-page') {
-        return [];
-    }
-
-    const areaPages = contentLib.query({
-        start: 0,
-        count: 1000,
-        contentTypes: ['no.nav.navno:area-page'],
-        filters: {
-            boolean: {
-                must: {
-                    hasValue: {
-                        field: 'data.area',
-                        values: forceArray(content.data.area),
-                    },
-                },
-            },
-        },
-    }).hits;
-
-    logger.info(`Found ${areaPages.length} relevant area pages`);
-
-    return areaPages;
 };
 
 // Contact-option parts for chat which does not have a sharedContactInformation field set will have
@@ -259,12 +197,9 @@ const getCustomReferences = (content: Content | null) => {
     }
 
     return [
-        ...getHtmlAreaReferences(content),
-        ...getGlobalValueCalculatorReferences(content),
+        ...getStringTypeReferences(content),
         ...getOverviewReferences(content),
-        ...getProductDetailsReferences(content),
         ...getFormDetailsReferences(content),
-        ...getSituationAreaPageReferences(content),
         ...getOfficeBranchPagesIfEditorial(content),
         ...getChatContactInfoReferences(content),
     ];
@@ -438,8 +373,7 @@ export const findReferences = ({
     const references = _findReferences({
         id,
         branch,
-        deadline,
-        withDeepSearch,
+        withDeepSearch: false,
     });
 
     if (!references) {

--- a/src/main/resources/site/layouts/situation-flex-cols/situation-flex-cols-config.ts
+++ b/src/main/resources/site/layouts/situation-flex-cols/situation-flex-cols-config.ts
@@ -21,7 +21,7 @@ export interface SituationFlexColsConfig {
   toggleCopyButton: boolean;
 
   /**
-   * For varehylle
+   * Innstilling for varehyller
    */
   shelf?:
     | {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Erstatter diverse spesialiserte søk for edge-cases med et generelt fulltext-query i alle felter. Dette skal fange opp alle "ikke-referanse-referanser" satt via custom-selectors, macroer osv.
- Søker alltid i alle layers for å sikre at endringer som påvirker innhold på tvers av layers alltid trigger invalidering. Må undersøke litt performance på dette og kanskje optimalisere litt (f.eks. modifisere queryene for å kunne treffe lokalisert innhold). Tar det før vi aktiverer layers i prod.