### PR TITLE
Reduserer varselnivå fra critical til error ved feilet legacy office import

### DIFF
--- a/src/main/resources/lib/officeInformation/index.ts
+++ b/src/main/resources/lib/officeInformation/index.ts
@@ -233,7 +233,7 @@ export const fetchAndUpdateOfficeInfo = (retry?: boolean) => {
             logger.error('Failed to fetch legacy office info, retrying in 5 minutes');
             runOfficeInfoUpdateTask(false, new Date(Date.now() + fiveMinutes).toISOString());
         } else {
-            logger.critical('Failed to fetch legacy office info from norg2');
+            logger.error('Failed to fetch legacy office info from norg2');
         }
         return;
     }


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Feilet legacy office import varsler om kritisk feil. Man kan jo diskutere hvor grensen går for hva som er kritisk, men i sommer skaper dette mye støy i logger og Slack-varsler, så jeg reduserer til å logge som error frem til vi kan ta en prat etter ferien slik at vi ikke risikerer å gå glipp av viktigere varsler.