### PR TITLE
Sørger for at visse content types aldri lokaliseres til layers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
                 "prettier": "3.0.2",
                 "striptags": "3.2.0",
                 "ts-jest": "29.1.1",
-                "typescript": "5.1.6"
+                "typescript": "5.2.2"
             }
         },
         "../babel-plugin-inline-import": {
@@ -9795,9 +9795,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -17172,9 +17172,9 @@
             }
         },
         "typescript": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
             "dev": true
         },
         "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
         "prettier": "3.0.2",
         "striptags": "3.2.0",
         "ts-jest": "29.1.1",
-        "typescript": "5.1.6"
+        "typescript": "5.2.2"
     }
 }


### PR DESCRIPTION
Verdiene fra `no.nav.navno:payout-dates`, `no.nav.navno:global-value-set` og `no.nav.navno:global-case-time-set` skal alltid være identiske på tvers av språkversjoner. Sørger derfor for at disse ikke kan lokaliseres til layers.