### PR TITLE
Jobb for å reindeksere html-fragmenter

### DIFF
--- a/src/main/resources/lib/paths/custom-paths/custom-path.test.ts
+++ b/src/main/resources/lib/paths/custom-paths/custom-path.test.ts
@@ -13,6 +13,7 @@ const contentWithoutCustomPath: Content = {
     _id: 'bfb67caa-c149-4302-bdb6-09f2ee0c3649',
     _name: 'test-side',
     _path: '/www.nav.no/test-side',
+    _versionKey: 'asdf',
     creator: 'user:system:su',
     modifier: 'user:system:su',
     createdTime: '2022-05-09T10:44:58.676477300Z',

--- a/src/main/resources/lib/reindex-fragments.ts
+++ b/src/main/resources/lib/reindex-fragments.ts
@@ -1,0 +1,165 @@
+import { getRepoConnection } from './utils/repo-utils';
+import { RepoConnection, RepoNode } from '/lib/xp/node';
+import { CONTENT_ROOT_REPO_ID } from './constants';
+import { logger } from './utils/logging';
+import { Content } from '/lib/xp/content';
+
+const addHtmlAreaIndexConfig = (
+    repo: RepoConnection,
+    fragment: RepoNode<Content<'portal:fragment'>>
+): 'changed' | 'unchanged' | 'error' => {
+    const { _id, _path, _indexConfig } = fragment;
+    const { configs } = _indexConfig;
+
+    if (!configs) {
+        logger.error(`Fragment ${_path} has no configs!`);
+        return 'error';
+    }
+
+    const hasHtmlAreaConfig = configs.some(
+        (config) => config.path === 'components.part.config.no-nav-navno.html-area'
+    );
+
+    const hasHtmlAreaHtmlConfig = configs.some(
+        (config) => config.path === 'components.part.config.no-nav-navno.html-area.html'
+    );
+
+    if (hasHtmlAreaConfig && hasHtmlAreaHtmlConfig) {
+        logger.info(`Fragment ${_path} already has updated index configs`);
+        return 'unchanged';
+    }
+
+    try {
+        repo.modify({
+            key: _id,
+            editor: (node) => {
+                if (!hasHtmlAreaConfig) {
+                    logger.info(`Adding html-area config to ${_path}`);
+
+                    node._indexConfig.configs.push({
+                        path: 'components.part.config.no-nav-navno.html-area',
+                        config: {
+                            decideByType: true,
+                            enabled: true,
+                            nGram: false,
+                            fulltext: false,
+                            includeInAllText: false,
+                            path: false,
+                            indexValueProcessors: [],
+                            languages: [],
+                        },
+                    });
+                }
+
+                if (!hasHtmlAreaHtmlConfig) {
+                    logger.info(`Adding html-area.html config to ${_path}`);
+
+                    node._indexConfig.configs.push({
+                        path: 'components.part.config.no-nav-navno.html-area.html',
+                        config: {
+                            decideByType: false,
+                            enabled: true,
+                            nGram: true,
+                            fulltext: true,
+                            includeInAllText: true,
+                            path: false,
+                            indexValueProcessors: ['htmlStripper'],
+                            languages: [],
+                        },
+                    });
+                }
+
+                return node;
+            },
+        });
+
+        logger.info(`Modifying ${_path}`);
+
+        return 'changed';
+    } catch (e) {
+        logger.error(`Error while modifying fragment ${_path} - ${e}`);
+        return 'error';
+    }
+};
+
+export const oneTimeReindexFragmentsJob = () => {
+    const draftRepo = getRepoConnection({
+        branch: 'draft',
+        repoId: CONTENT_ROOT_REPO_ID,
+        asAdmin: true,
+    });
+
+    const masterRepo = getRepoConnection({
+        branch: 'master',
+        repoId: CONTENT_ROOT_REPO_ID,
+        asAdmin: true,
+    });
+
+    const draftFragmentHits = draftRepo.query({
+        count: 2000,
+        query: 'type="portal:fragment" AND components.part.descriptor="no.nav.navno:html-area" AND _path LIKE "/content*"',
+    }).hits;
+
+    logger.info(`Found ${draftFragmentHits.length} fragments`);
+
+    let count = 0;
+    const fragmentsWithErrors: string[] = [];
+
+    draftFragmentHits.forEach(({ id }) => {
+        const draftFragment = draftRepo.get<Content<'portal:fragment'>>(id);
+        if (!draftFragment) {
+            logger.error(`Node not found for fragment - ${id}`);
+            fragmentsWithErrors.push(id);
+            return;
+        }
+
+        const masterFragment = masterRepo.get<Content<'portal:fragment'>>(id);
+        if (masterFragment) {
+            const masterResult = addHtmlAreaIndexConfig(draftRepo, masterFragment);
+
+            if (masterResult === 'error') {
+                logger.error(`Failed to modify fragment in master - ${id}`);
+                fragmentsWithErrors.push(id);
+                return;
+            }
+
+            draftRepo.push({ key: id, target: 'master', resolve: false, includeChildren: false });
+
+            const draftIsSameVersion = draftFragment._versionKey === masterFragment._versionKey;
+            if (draftIsSameVersion) {
+                logger.info(
+                    `Master node is the same version as draft - ${id} - ${masterFragment._versionKey}`
+                );
+
+                if (masterResult === 'changed') {
+                    count++;
+                }
+
+                return;
+            }
+        } else {
+            logger.info(`Node not found in master - ${id}`);
+        }
+
+        const draftResult = addHtmlAreaIndexConfig(draftRepo, draftFragment);
+        if (draftResult === 'error') {
+            logger.error(`Failed to modify fragment in draft - ${id}`);
+            fragmentsWithErrors.push(id);
+            return;
+        }
+
+        if (draftResult === 'changed') {
+            count++;
+        }
+    });
+
+    logger.info(
+        `Finished updating index config for ${count}/${draftFragmentHits.length} fragments`
+    );
+
+    if (fragmentsWithErrors.length > 0) {
+        logger.error(
+            `${fragmentsWithErrors.length} fragments had errors! ${fragmentsWithErrors.join(', ')}`
+        );
+    }
+};

--- a/src/main/resources/lib/search/search-event-handlers.ts
+++ b/src/main/resources/lib/search/search-event-handlers.ts
@@ -129,7 +129,7 @@ export const activateSearchIndexEventHandlers = () => {
             }
 
             event.data.nodes.forEach((nodeData) => {
-                if (nodeData.branch !== 'master') {
+                if (nodeData.branch !== 'master' || !nodeData.path.startsWith('/content/')) {
                     return;
                 }
 

--- a/src/main/resources/main.ts
+++ b/src/main/resources/main.ts
@@ -23,8 +23,8 @@ import { activateContentUpdateListener } from './lib/contentUpdate/content-updat
 
 updateClusterInfo();
 initLayersData();
-activateLayersEventListeners();
 
+// activateLayersEventListeners();
 // activateCacheEventListeners();
 // activateSitemapDataUpdateEventListener();
 // activateContentListItemUnpublishedListener();

--- a/src/main/resources/main.ts
+++ b/src/main/resources/main.ts
@@ -25,12 +25,12 @@ updateClusterInfo();
 initLayersData();
 activateLayersEventListeners();
 
-activateCacheEventListeners();
-activateSitemapDataUpdateEventListener();
-activateContentListItemUnpublishedListener();
-activateCustomPathNodeListeners();
-activateSearchIndexEventHandlers();
-activateContentUpdateListener();
+// activateCacheEventListeners();
+// activateSitemapDataUpdateEventListener();
+// activateContentListItemUnpublishedListener();
+// activateCustomPathNodeListeners();
+// activateSearchIndexEventHandlers();
+// activateContentUpdateListener();
 
 hookLibsWithTimeTravel();
 

--- a/src/main/resources/types/xp-libs/content.d.ts
+++ b/src/main/resources/types/xp-libs/content.d.ts
@@ -47,6 +47,7 @@ declare module '*/lib/xp/content' {
                 readonly _id: string;
                 readonly _name: string;
                 readonly _path: string;
+                readonly _versionKey: string;
                 readonly type: Type;
                 readonly creator: string;
                 readonly modifier: string;

--- a/src/main/resources/webapp/webapp.ts
+++ b/src/main/resources/webapp/webapp.ts
@@ -14,11 +14,17 @@ import {
     SEARCH_NODES_UPDATE_ABORT_EVENT,
 } from '../lib/search/search-event-handlers';
 import { pushLayerContentToMaster } from '../lib/localization/layers-data';
+import { oneTimeReindexFragmentsJob } from '../lib/reindex-fragments';
 
 type ActionsMap = { [key: string]: { description: string; callback: () => any } };
 
 const view = resolve('webapp.html');
+
 const validActions: ActionsMap = {
+    updateFragmentsIndexConfig: {
+        description: 'Oppdater index-config for html-fragmenter',
+        callback: oneTimeReindexFragmentsJob,
+    },
     norg: {
         description: 'Oppdater kontor-info fra norg',
         callback: () => runOfficeBranchFetchTask(),


### PR DESCRIPTION
## Oppsummering av hva som er gjort
XP hadde en bug med indeksering av component-data i fragmenter. Denne ble fikset sånn ca april 2023, men hadde ikke tilbakevirkende effekt, dvs fragmenter som ikke har blitt endret siden fiksen mangler fortsatt felter i index-configen.

Legger til en jobb som må kjøres en gang for å oppdatere indexen på alle fragmenter. Er viktig at indexen er korrekt slik at referanse-søket fungerer ved layers-migreringen.