### PR TITLE
Kjører global-value req handlers som kallende bruker

### DIFF
--- a/src/main/resources/lib/localization/locale-context.ts
+++ b/src/main/resources/lib/localization/locale-context.ts
@@ -7,7 +7,7 @@ import { getLayersData } from './layers-data';
 type RunInLocaleContextOptions = Omit<RunInContextOptions, 'repository'> & { locale: string };
 
 export const runInLocaleContext = <ReturnType>(
-    { locale, branch, asAdmin, attributes }: RunInLocaleContextOptions,
+    { locale, branch, asAdmin, asCurrentUser, attributes }: RunInLocaleContextOptions,
     func: () => ReturnType
 ): ReturnType => {
     const { localeToRepoIdMap, defaultLocale } = getLayersData();
@@ -27,6 +27,7 @@ export const runInLocaleContext = <ReturnType>(
             repository: repoIdActual,
             branch,
             asAdmin,
+            asCurrentUser,
             attributes: { ...attributes, locale: localeActual },
         },
         func

--- a/src/main/resources/services/globalValues/globalValues.ts
+++ b/src/main/resources/services/globalValues/globalValues.ts
@@ -47,5 +47,7 @@ export const get = (req: XP.Request) => {
     const { defaultLocale } = getLayersData();
 
     // Global values should always use the default layer
-    return runInLocaleContext({ locale: defaultLocale }, () => reqHandler(req));
+    return runInLocaleContext({ locale: defaultLocale, asCurrentUser: true }, () =>
+        reqHandler(req)
+    );
 };


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Kjører request-handlere for global-value services i context av kallende bruker istedenfor systembruker, ettersom brukers tilganger skal bestemme hvilke handlinger som kan utføres.