### PR TITLE
Fjerner antallsbegrensninger for seksjon for snarveier

### DIFF
--- a/src/main/resources/site/content-types/front-page-nested/front-page-nested.ts
+++ b/src/main/resources/site/content-types/front-page-nested/front-page-nested.ts
@@ -57,7 +57,7 @@ export interface FrontPageNested {
   /**
    * Skriv inn ønsket kort-url
    */
-  customPath?: string;
+  customPath: string;
 
   /**
    * Legg til andre språkversjoner

--- a/src/main/resources/site/parts/frontpage-shortcuts/frontpage-shortcuts.xml
+++ b/src/main/resources/site/parts/frontpage-shortcuts/frontpage-shortcuts.xml
@@ -7,7 +7,7 @@
         </input>
         <item-set name="shortcuts">
             <label>Velg snarveier</label>
-            <occurrences minimum="0" maximum="4"/>
+            <occurrences minimum="0" maximum="0"/>
             <items>
                 <input name="customTitle" type="TextLine">
                     <label>Tittel på snarvei</label>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Fjerner antallsbegrensninger for "Seksjon for snarveier". Denne brukes kun på forsider og styres av vår egen redaksjon, så jeg har avklart med Janne at det er OK å fjerne begrensningen.

## Testing
Testes i dev / q6