### PR TITLE
Setter locale-context ved kjøring av redirect-queries

### DIFF
--- a/src/main/resources/services/sitecontent/resolve-redirects.ts
+++ b/src/main/resources/services/sitecontent/resolve-redirects.ts
@@ -213,5 +213,9 @@ export const getRedirectFallback = ({
             getParentRedirectContent(pathRequested) ||
             getParentRedirectContent(`${REDIRECTS_ROOT_PATH}${strippedPath}`);
 
-        return redirectContent ? runSitecontentGuillotineQuery(redirectContent, branch) : null;
+        return redirectContent
+            ? runInLocaleContext({ locale: redirectContent.language }, () =>
+                  runSitecontentGuillotineQuery(redirectContent, branch)
+              )
+            : null;
     });


### PR DESCRIPTION
Sørger for at redirects går til riktig layer