### PR TITLE
Bruker alltid context-relevant path for editor paths

### DIFF
--- a/src/main/resources/lib/paths/editor-path.ts
+++ b/src/main/resources/lib/paths/editor-path.ts
@@ -1,22 +1,10 @@
 import * as contextLib from '/lib/xp/context';
-import * as contentLib from '/lib/xp/content';
-import { logger } from '../utils/logging';
 import { getContentProjectIdFromRepoId } from '../utils/repo-utils';
-import { CONTENT_ROOT_PROJECT_ID, CONTENT_STUDIO_PATH_PREFIX } from '../constants';
-import { isContentLocalized } from '../localization/locale-utils';
+import { CONTENT_ROOT_REPO_ID, CONTENT_STUDIO_PATH_PREFIX } from '../constants';
 
 export const buildEditorPathFromContext = (contentId: string) => {
-    const { repository } = contextLib.get();
-    if (!repository) {
-        logger.error('Could not determine current repo from context!');
-    }
-
-    const content = contentLib.get({ key: contentId });
-
-    const projectId =
-        repository && content && isContentLocalized(content)
-            ? getContentProjectIdFromRepoId(repository)
-            : CONTENT_ROOT_PROJECT_ID;
+    const repoId = contextLib.get().repository || CONTENT_ROOT_REPO_ID;
+    const projectId = getContentProjectIdFromRepoId(repoId);
 
     return `${CONTENT_STUDIO_PATH_PREFIX}/${projectId}/edit/${contentId}`;
 };


### PR DESCRIPTION
Benyttes for å lenke til innhold fra custom selectors i content studio