### PR TITLE
Tekst-disclaimer for språk på skjemadetalj og mellomsteg

### DIFF
--- a/src/main/resources/lib/guillotine/queries/fragments/content-types/formIntermediateStepFragment.graphql
+++ b/src/main/resources/lib/guillotine/queries/fragments/content-types/formIntermediateStepFragment.graphql
@@ -13,6 +13,7 @@ fragment contentIntermediateStep on no_nav_navno_FormIntermediateStep {
         steps {
             label
             explanation
+            languageDisclaimer
             nextStep {
                 _selected
                 next {
@@ -23,6 +24,7 @@ fragment contentIntermediateStep on no_nav_navno_FormIntermediateStep {
                     steps {
                         label
                         explanation
+                        languageDisclaimer
                         nextStep {
                             _selected
                             external {

--- a/src/main/resources/site/content-types/form-details/form-details.ts
+++ b/src/main/resources/site/content-types/form-details/form-details.ts
@@ -21,6 +21,11 @@ export interface FormDetails {
   ingress?: string;
 
   /**
+   * Informasjon om språk
+   */
+  languageDisclaimer?: string;
+
+  /**
    * Målgruppe
    */
   audience: {

--- a/src/main/resources/site/content-types/form-details/form-details.xml
+++ b/src/main/resources/site/content-types/form-details/form-details.xml
@@ -27,6 +27,9 @@
                 <input name="ingress" type="HtmlArea">
                     <label>Ingress</label>
                 </input>
+                <input name="languageDisclaimer" type="TextArea">
+                    <label>Informasjon om språk</label>
+                </input>
                 <option-set name="audience">
                     <label>Målgruppe</label>
                     <occurrences minimum="1" maximum="1"/>

--- a/src/main/resources/site/mixins/form-intermediate-step-data-action/form-intermediate-step-data-action.ts
+++ b/src/main/resources/site/mixins/form-intermediate-step-data-action/form-intermediate-step-data-action.ts
@@ -9,4 +9,9 @@ export interface FormIntermediateStepDataAction {
    * Ekstra forklaring
    */
   explanation?: string;
+
+  /**
+   * Informasjon om språk
+   */
+  languageDisclaimer?: string;
 }

--- a/src/main/resources/site/mixins/form-intermediate-step-data-action/form-intermediate-step-data-action.xml
+++ b/src/main/resources/site/mixins/form-intermediate-step-data-action/form-intermediate-step-data-action.xml
@@ -8,5 +8,8 @@
         <label>Ekstra forklaring</label>
         <occurrences minimum="0" maximum="1"/>
     </input>
+    <input name="languageDisclaimer" type="TextArea">
+        <label>Informasjon om språk</label>
+    </input>
   </form>
 </mixin>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Redaktørene trenger et eget tekstfelt for å legge inn tekstdisclaimer for skjemadetalj og mellomsteg.

## Testing
Testet av Janne og Tuva i Q6.
