### PR TITLE
Optimaliserer sitemap-generering

### DIFF
--- a/src/main/resources/lib/sitemap/sitemap.ts
+++ b/src/main/resources/lib/sitemap/sitemap.ts
@@ -77,6 +77,8 @@ const shouldIncludeContent = (content: Content<any> | null): content is Content 
         isContentLocalized(content)
     );
 
+const getId = (contentId: string, locale: string) => `${contentId}-${locale}`;
+
 const getUrl = (content: Content<any>, locale: string) => {
     if (content.data?.canonicalUrl) {
         return content.data.canonicalUrl;
@@ -86,10 +88,12 @@ const getUrl = (content: Content<any>, locale: string) => {
     return `${URLS.FRONTEND_ORIGIN}${pathname}`;
 };
 
-const transformLanguageVersion = (languageSelectorData: LanguageSelectorData): LanguageVersion => ({
-    language: languageSelectorData.language,
-    url: `${URLS.FRONTEND_ORIGIN}${languageSelectorData._path}`,
-});
+const transformLanguageVersion = (languageSelectorData: LanguageSelectorData): LanguageVersion => {
+    return {
+        language: languageSelectorData.language,
+        url: `${URLS.FRONTEND_ORIGIN}${languageSelectorData._path}`,
+    };
+};
 
 const getSitemapEntry = (content: Content, locale: string): SitemapEntry => {
     const languageVersions = getLanguageVersions({
@@ -99,7 +103,7 @@ const getSitemapEntry = (content: Content, locale: string): SitemapEntry => {
     }).map(transformLanguageVersion);
 
     return {
-        id: `${content._id}-${locale}`,
+        id: getId(content._id, locale),
         url: getUrl(content, locale),
         modifiedTime: content.modifiedTime,
         language: content.language,
@@ -110,11 +114,12 @@ const getSitemapEntry = (content: Content, locale: string): SitemapEntry => {
 const updateSitemapEntry = (contentId: string, locale: string) =>
     runInLocaleContext({ branch: 'master', locale }, () => {
         const content = contentLib.get({ key: contentId });
+        const id = getId(contentId, locale);
 
         if (shouldIncludeContent(content)) {
-            sitemapData.set(contentId, getSitemapEntry(content, locale));
+            sitemapData.set(id, getSitemapEntry(content, locale));
         } else if (sitemapData.get(contentId)) {
-            sitemapData.remove(contentId);
+            sitemapData.remove(id);
         }
     });
 

--- a/src/main/resources/lib/sitemap/sitemap.ts
+++ b/src/main/resources/lib/sitemap/sitemap.ts
@@ -143,9 +143,6 @@ const updateSitemapEntry = (contentId: string, locale: string) =>
     });
 
 const generateSitemapEntries = (): SitemapEntry[] => {
-    logger.info(`Starting!`);
-    const start = Date.now();
-
     const repoIdContentBuckets = queryAllLayersToRepoIdBuckets({
         branch: 'master',
         state: 'localized',
@@ -172,8 +169,6 @@ const generateSitemapEntries = (): SitemapEntry[] => {
             },
         },
     });
-
-    logger.info(`Finished query after ${Date.now() - start}`);
 
     const sitemapEntries: SitemapEntry[] = [];
 

--- a/src/main/resources/lib/sitemap/sitemap.ts
+++ b/src/main/resources/lib/sitemap/sitemap.ts
@@ -119,6 +119,9 @@ const updateSitemapEntry = (contentId: string, locale: string) =>
     });
 
 const generateSitemapEntries = (): SitemapEntry[] => {
+    logger.info(`Starting!`);
+    const start = Date.now();
+
     const localeContentBuckets = queryAllLayersToRepoIdBuckets({
         branch: 'master',
         state: 'localized',
@@ -145,6 +148,8 @@ const generateSitemapEntries = (): SitemapEntry[] => {
             },
         },
     });
+
+    logger.info(`Finished query after ${Date.now() - start}`);
 
     return Object.entries(localeContentBuckets)
         .map(([locale, contents]) => contents.map((content) => getSitemapEntry(content, locale)))

--- a/src/main/resources/lib/sitemap/sitemap.ts
+++ b/src/main/resources/lib/sitemap/sitemap.ts
@@ -133,12 +133,12 @@ const buildSitemapEntry = (
 const updateSitemapEntry = (contentId: string, locale: string) =>
     runInLocaleContext({ branch: 'master', locale }, () => {
         const content = contentLib.get({ key: contentId });
-        const id = getKey(contentId, locale);
+        const key = getKey(contentId, locale);
 
         if (shouldIncludeContent(content)) {
-            sitemapEntriesMap.set(id, buildSitemapEntry(content, locale, true));
+            sitemapEntriesMap.set(key, buildSitemapEntry(content, locale, true));
         } else if (sitemapEntriesMap.get(contentId)) {
-            sitemapEntriesMap.delete(id);
+            sitemapEntriesMap.delete(key);
         }
     });
 
@@ -261,13 +261,13 @@ const updateSitemapData = (entries: SitemapEntry[]) => {
         return;
     }
 
-    const siteMapDataNew = new Map<string, SitemapEntry>();
+    const sitemapEntriesMapNew = new Map<string, SitemapEntry>();
 
     entries.forEach((entry) => {
-        siteMapDataNew.set(entry._key, entry);
+        sitemapEntriesMapNew.set(entry._key, entry);
     });
 
-    sitemapEntriesMap = siteMapDataNew;
+    sitemapEntriesMap = sitemapEntriesMapNew;
 
     logger.info(`Updated sitemap data with ${entries.length} entries`);
 };

--- a/src/main/resources/lib/sitemap/sitemap.ts
+++ b/src/main/resources/lib/sitemap/sitemap.ts
@@ -8,16 +8,13 @@ import { URLS } from '../constants';
 import { createOrUpdateSchedule } from '../scheduling/schedule-job';
 import { contentTypesInSitemap } from '../contenttype-lists';
 import { logger } from '../utils/logging';
-import {
-    getLanguageVersions,
-    LanguageSelectorData,
-} from '../localization/resolve-language-versions';
 import { getLayersData } from '../localization/layers-data';
 import { runInLocaleContext } from '../localization/locale-context';
 import { isContentLocalized } from '../localization/locale-utils';
 import { queryAllLayersToRepoIdBuckets } from '../localization/layers-repo-utils/query-all-layers';
 import { getPublicPath } from '../paths/public-path';
 import { customListenerType } from '../utils/events';
+import { forceArray, iterableToArray } from '../utils/array-utils';
 
 const MAX_COUNT = 50000;
 const EVENT_TYPE_SITEMAP_GENERATED = 'sitemap-generated';
@@ -29,46 +26,23 @@ type LanguageVersion = {
 };
 
 type SitemapEntry = {
-    id: string;
+    _contentId: string;
+    _contentLocale: string;
+    _legacyLanguages: string[];
+    _key: string;
     url: string;
     modifiedTime: string;
-    language?: string;
+    language: string;
     languageVersions?: LanguageVersion[];
-};
-
-type SitemapData = {
-    entries: { [key: string]: SitemapEntry };
-    clear: () => void;
-    get: (key: string) => SitemapEntry;
-    set: (key: string, value: SitemapEntry) => void;
-    remove: (key: string) => void;
-    getEntries: () => SitemapEntry[];
 };
 
 let isGenerating = false;
 
-const sitemapData: SitemapData = {
-    entries: {},
-    clear: function () {
-        this.entries = {};
-    },
-    get: function (key) {
-        return this.entries[key];
-    },
-    set: function (key, value) {
-        this.entries[key] = value;
-    },
-    remove: function (key) {
-        delete this.entries[key];
-    },
-    getEntries: function () {
-        return Object.values(this.entries);
-    },
-};
+let sitemapEntriesMap = new Map<string, SitemapEntry>();
 
 const contentTypesInSitemapSet: ReadonlySet<string> = new Set(contentTypesInSitemap);
 
-const shouldIncludeContent = (content: Content<any> | null): content is Content =>
+const shouldIncludeContent = (content: Content | null): content is Content =>
     !!(
         content &&
         contentTypesInSitemapSet.has(content.type) &&
@@ -77,9 +51,9 @@ const shouldIncludeContent = (content: Content<any> | null): content is Content 
         isContentLocalized(content)
     );
 
-const getId = (contentId: string, locale: string) => `${contentId}-${locale}`;
+const getKey = (contentId: string, locale: string) => `${contentId}-${locale}`;
 
-const getUrl = (content: Content<any>, locale: string) => {
+const getUrl = (content: Content, locale: string) => {
     if (content.data?.canonicalUrl) {
         return content.data.canonicalUrl;
     }
@@ -88,38 +62,83 @@ const getUrl = (content: Content<any>, locale: string) => {
     return `${URLS.FRONTEND_ORIGIN}${pathname}`;
 };
 
-const transformLanguageVersion = (languageSelectorData: LanguageSelectorData): LanguageVersion => {
+const transformLanguageVersion = (languageEntry: SitemapEntry): LanguageVersion => {
     return {
-        language: languageSelectorData.language,
-        url: `${URLS.FRONTEND_ORIGIN}${languageSelectorData._path}`,
+        language: languageEntry.language,
+        url: languageEntry.url,
     };
 };
 
-const getSitemapEntry = (content: Content, locale: string): SitemapEntry => {
-    const languageVersions = getLanguageVersions({
-        baseContent: content,
-        branch: 'master',
-        baseContentLocale: locale,
-    }).map(transformLanguageVersion);
+const resolveLanguageVersions = (sitemapEntry: SitemapEntry) => {
+    const { _contentId, _contentLocale } = sitemapEntry;
+    const { locales, defaultLocale } = getLayersData();
 
-    return {
-        id: getId(content._id, locale),
+    const localesToResolve = locales.filter((locale) => locale != _contentLocale);
+
+    const languageVersions = localesToResolve.reduce<SitemapEntry[]>((acc, locale) => {
+        const version = sitemapEntriesMap.get(getKey(_contentId, locale));
+        if (version) {
+            acc.push(version);
+        }
+
+        return acc;
+    }, []);
+
+    const legacyLanguages = sitemapEntriesMap.get(getKey(_contentId, defaultLocale))
+        ?._legacyLanguages;
+    if (legacyLanguages) {
+        legacyLanguages.forEach((languageRefContentId) => {
+            if (languageRefContentId === _contentId) {
+                return;
+            }
+
+            const version = sitemapEntriesMap.get(getKey(languageRefContentId, defaultLocale));
+            if (!version) {
+                return;
+            }
+
+            if (languageVersions.some((_version) => _version.language === version.language)) {
+                return;
+            }
+
+            languageVersions.push(version);
+        }, []);
+    }
+
+    return languageVersions.map(transformLanguageVersion);
+};
+
+const buildSitemapEntry = (
+    content: Content,
+    locale: string,
+    resolveLanguages: boolean
+): SitemapEntry => {
+    const sitemapEntry: SitemapEntry = {
+        _key: getKey(content._id, locale),
+        _contentId: content._id,
+        _contentLocale: locale,
+        _legacyLanguages: forceArray(content.data.languages),
         url: getUrl(content, locale),
         modifiedTime: content.modifiedTime,
         language: content.language,
-        ...(languageVersions && languageVersions.length > 0 && { languageVersions }),
     };
+
+    if (resolveLanguages) {
+        sitemapEntry.languageVersions = resolveLanguageVersions(sitemapEntry);
+    }
+
+    return sitemapEntry;
 };
 
 const updateSitemapEntry = (contentId: string, locale: string) =>
     runInLocaleContext({ branch: 'master', locale }, () => {
         const content = contentLib.get({ key: contentId });
-        const id = getId(contentId, locale);
+        const id = getKey(contentId, locale);
 
         if (shouldIncludeContent(content)) {
-            sitemapData.set(id, getSitemapEntry(content, locale));
-        } else if (sitemapData.get(contentId)) {
-            sitemapData.remove(id);
+            sitemapEntriesMap.set(id, buildSitemapEntry(content, locale, true));
+        } else if (sitemapEntriesMap.get(contentId)) {
+            sitemapEntriesMap.delete(id);
         }
     });
 
@@ -127,7 +146,7 @@ const generateSitemapEntries = (): SitemapEntry[] => {
     logger.info(`Starting!`);
     const start = Date.now();
 
-    const localeContentBuckets = queryAllLayersToRepoIdBuckets({
+    const repoIdContentBuckets = queryAllLayersToRepoIdBuckets({
         branch: 'master',
         state: 'localized',
         resolveContent: true,
@@ -156,13 +175,31 @@ const generateSitemapEntries = (): SitemapEntry[] => {
 
     logger.info(`Finished query after ${Date.now() - start}`);
 
-    return Object.entries(localeContentBuckets)
-        .map(([locale, contents]) => contents.map((content) => getSitemapEntry(content, locale)))
-        .flat();
+    const sitemapEntries: SitemapEntry[] = [];
+
+    Object.entries(repoIdContentBuckets).forEach(([repoId, contents]) => {
+        const locale = getLayersData().repoIdToLocaleMap[repoId];
+
+        contents.forEach((content) => {
+            const entry = buildSitemapEntry(content, locale, false);
+            sitemapEntries.push(entry);
+        });
+    });
+
+    updateSitemapData(sitemapEntries);
+
+    // Iterate over all entries again after to resolve language versions
+    // We need the initial iteration done first to ensure language references
+    // can be resolved from the sitemapData map
+    sitemapEntries.forEach((sitemapEntry) => {
+        sitemapEntry.languageVersions = resolveLanguageVersions(sitemapEntry);
+    });
+
+    return sitemapEntries;
 };
 
 export const getAllSitemapEntries = () => {
-    return sitemapData.getEntries();
+    return iterableToArray(sitemapEntriesMap.values());
 };
 
 const generateAndBroadcastSitemapData = () => {
@@ -229,11 +266,13 @@ const updateSitemapData = (entries: SitemapEntry[]) => {
         return;
     }
 
-    sitemapData.clear();
+    const siteMapDataNew = new Map<string, SitemapEntry>();
 
     entries.forEach((entry) => {
-        sitemapData.set(entry.id, entry);
+        siteMapDataNew.set(entry._key, entry);
     });
+
+    sitemapEntriesMap = siteMapDataNew;
 
     logger.info(`Updated sitemap data with ${entries.length} entries`);
 };

--- a/src/main/resources/lib/utils/array-utils.ts
+++ b/src/main/resources/lib/utils/array-utils.ts
@@ -39,3 +39,13 @@ export const removeDuplicatesFilter = <Type>(isEqualPredicate?: (a: Type, b: Typ
           }
         : (item: Type, index: number, array: Type[] | ReadonlyArray<Type>) =>
               array.indexOf(item) === index;
+
+export const iterableToArray = <Type>(iterable: IterableIterator<Type>): Type[] => {
+    const array: Type[] = [];
+
+    for (const item of iterable) {
+        array.push(item);
+    }
+
+    return array;
+};

--- a/src/main/resources/main.ts
+++ b/src/main/resources/main.ts
@@ -45,9 +45,9 @@ if (clusterLib.isMaster()) {
 
     // This is somewhat annoying for local development, as it will run a fairly heavy task and spam
     // the logs when generating the sitemap. This happens on every redeploy of the app.
-    // if (app.config.env !== 'localhost') {
-    generateSitemapDataAndActivateSchedule();
-    // }
+    if (app.config.env !== 'localhost') {
+        generateSitemapDataAndActivateSchedule();
+    }
 }
 
 log.info('Finished running main');

--- a/src/main/resources/main.ts
+++ b/src/main/resources/main.ts
@@ -45,9 +45,9 @@ if (clusterLib.isMaster()) {
 
     // This is somewhat annoying for local development, as it will run a fairly heavy task and spam
     // the logs when generating the sitemap. This happens on every redeploy of the app.
-    if (app.config.env !== 'localhost') {
-        generateSitemapDataAndActivateSchedule();
-    }
+    // if (app.config.env !== 'localhost') {
+    generateSitemapDataAndActivateSchedule();
+    // }
 }
 
 log.info('Finished running main');


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Største forbedringen her kommer fra omskrivning av måten språkversjoner resolves på. Bruker nå eksisterende data fra det initielle queryet for å resolve språkversjons-referanser, fremfor å gjøre nye queries for hvert enkelt innhold.

Reduserer tiden det tar å generere sitemappet til ca. 1/5 av tidligere (1500 sec -> 300 sec i dev).