### PR TITLE
Fikser bug med kort-url for mellomsteg

### DIFF
--- a/src/main/resources/lib/controllers/form-intermediate-step-controller.ts
+++ b/src/main/resources/lib/controllers/form-intermediate-step-controller.ts
@@ -21,8 +21,12 @@ const insertCustomPath = (req: XP.Request) => {
         return;
     }
 
-    const currentCustomPath = content.data.customPath;
-    if (formIntermediateStepValidateCustomPath(currentCustomPath, content)) {
+    if (!content.valid) {
+        logger.info(`Content ${content._id} is not valid - skipping customPath generation for now`);
+        return;
+    }
+
+    if (formIntermediateStepValidateCustomPath(content.data.customPath, content)) {
         return;
     }
 

--- a/src/main/resources/lib/paths/custom-paths/custom-path-special-types.ts
+++ b/src/main/resources/lib/paths/custom-paths/custom-path-special-types.ts
@@ -28,7 +28,7 @@ export const formIntermediateStepValidateCustomPath = (
     const audienceSegment = getAudienceSegmentWithSlash(content);
 
     const isValid = new RegExp(
-        `${FORM_INTERMEDIATE_STEP_CUSTOM_PATH_PREFIX}${audienceSegment}/.+`
+        `${FORM_INTERMEDIATE_STEP_CUSTOM_PATH_PREFIX}${audienceSegment}/(?!unnamed).+`
     ).test(customPath);
 
     return isValid;


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Mellomsteg vil i mange tilfeller få en initiell kort-url basert på placeholder-navnet til nyopprettet content, eks /start/unnamed-<uuid>. Fikser det slik at kort-url ikke genereres automatisk før content'et er valid. Tar dessuten å fikser opp de eksisterende unnamed-path'ene når mellomstegene åpnes i CS.

Annen endring: Ekskluderer innhold fra arkivet med multirepo layer queries