### PR TITLE
Kjører visse jobber på en enkelt data node

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     include "com.enonic.xp:lib-content:${xpVersion}"
     include "com.enonic.xp:lib-context:${xpVersion}"
     include "com.enonic.xp:lib-event:${xpVersion}"
+    include "com.enonic.xp:lib-grid:${xpVersion}"
     include "com.enonic.xp:lib-io:${xpVersion}"
     include "com.enonic.xp:lib-node:${xpVersion}"
     include "com.enonic.xp:lib-portal:${xpVersion}"

--- a/src/main/resources/lib/cache/cache-invalidate.ts
+++ b/src/main/resources/lib/cache/cache-invalidate.ts
@@ -1,4 +1,3 @@
-import * as clusterLib from '/lib/xp/cluster';
 import * as taskLib from '/lib/xp/task';
 import {
     frontendInvalidateAllDeferred,
@@ -9,6 +8,7 @@ import { generateCacheEventId, NodeEventData } from './utils';
 import { findPathsToInvalidate } from './find-paths-to-invalidate';
 import { invalidateLocalCache, sendLocalCacheInvalidationEvent } from './local-cache';
 import { logger } from '../utils/logging';
+import { isMainDatanode } from '../cluster-utils/main-datanode';
 
 export type InvalidateCacheParams = {
     node: NodeEventData;
@@ -61,9 +61,9 @@ const _invalidateCacheForNode = (params: InvalidateCacheParams) => {
         sendLocalCacheInvalidationEvent();
     }
 
-    // If this invalidation is running on every node, we only want the master node to send
-    // invalidation calls to the frontend
-    if (isRunningClusterWide && !clusterLib.isMaster()) {
+    // If this invalidation is running on every node, we only want a single node to perform
+    // the reference search and send calls to the frontend for invalidation
+    if (isRunningClusterWide && !isMainDatanode()) {
         return;
     }
 

--- a/src/main/resources/lib/cluster-utils/cluster-api.ts
+++ b/src/main/resources/lib/cluster-utils/cluster-api.ts
@@ -1,5 +1,5 @@
 import httpClient from '/lib/http-client';
-import { logger } from './logging';
+import { logger } from '../utils/logging';
 
 type LocalNodeInfo = {
     isMaster: boolean;
@@ -9,7 +9,7 @@ type LocalNodeInfo = {
     numberOfNodesSeen: number;
 };
 
-type ClusterNodeInfo = {
+export type ClusterNodeInfo = {
     isMaster: boolean;
     id: string;
     hostName: string;
@@ -22,7 +22,7 @@ type ClusterNodeInfo = {
 
 export type ClusterState = 'RED' | 'YELLOW' | 'GREEN';
 
-type ClusterInfo = {
+export type ClusterInfo = {
     name: string;
     localNode: LocalNodeInfo;
     members: ClusterNodeInfo[];
@@ -49,7 +49,7 @@ export const requestClusterInfo = () => {
     }
 };
 
-export const getLocalServerName = (clusterInfo: ClusterInfo) => {
+const getLocalServerName = (clusterInfo: ClusterInfo) => {
     const localMember = clusterInfo.members.find(
         (member) => member.id === clusterInfo.localNode.id
     );

--- a/src/main/resources/lib/cluster-utils/main-datanode.ts
+++ b/src/main/resources/lib/cluster-utils/main-datanode.ts
@@ -14,7 +14,6 @@ const CURRENT_MAIN_DATANODE_KEY = 'current-node';
 const pickDatanode = (clusterInfo: ClusterInfo): ClusterNodeInfo | null => {
     const datanode = clusterInfo.members.find((member) => member.isDataNode);
     if (!datanode) {
-        logger.critical('No data nodes found!');
         return null;
     }
 
@@ -67,10 +66,11 @@ export const refreshMainDatanode = () => {
 
     const newMainDatanode = pickDatanode(clusterInfo);
     if (!newMainDatanode) {
+        logger.critical('No data nodes found!');
         return;
     }
 
-    logger.info(`Setting main datanode to ${newMainDatanode.name}`);
+    logger.info(`Setting main data node to ${newMainDatanode.name}`);
 
     sharedMap.set({
         key: CURRENT_MAIN_DATANODE_KEY,

--- a/src/main/resources/lib/cluster-utils/main-datanode.ts
+++ b/src/main/resources/lib/cluster-utils/main-datanode.ts
@@ -48,8 +48,6 @@ const getCurrentMainDatanode = (sharedMap = getSharedMap()) => {
 };
 
 export const refreshMainDatanode = () => {
-    logger.info('Refreshing main datanode');
-
     const clusterInfo = requestClusterInfo();
     if (!clusterInfo) {
         logger.critical('Failed to get cluster info!');
@@ -68,6 +66,11 @@ export const refreshMainDatanode = () => {
     }
 
     const newMainDatanode = pickDatanode(clusterInfo);
+    if (!newMainDatanode) {
+        return;
+    }
+
+    logger.info(`Setting main datanode to ${newMainDatanode.name}`);
 
     sharedMap.set({
         key: CURRENT_MAIN_DATANODE_KEY,

--- a/src/main/resources/lib/cluster-utils/main-datanode.ts
+++ b/src/main/resources/lib/cluster-utils/main-datanode.ts
@@ -4,8 +4,10 @@ import { clusterInfo, ClusterInfo, ClusterNodeInfo, requestClusterInfo } from '.
 import { logger } from '../utils/logging';
 import { APP_DESCRIPTOR } from '../constants';
 
-const SHARED_MAP_KEY = 'main-datanode';
+// This is used for picking a single data node for running certain jobs from event handlers
+// or schedules, which we want to run only on a single (data) node
 
+const SHARED_MAP_KEY = 'main-datanode';
 const CURRENT_MAIN_DATANODE_KEY = 'current-node';
 
 const pickDatanode = (clusterInfo: ClusterInfo): ClusterNodeInfo | null => {

--- a/src/main/resources/lib/cluster-utils/run-on-datanode.ts
+++ b/src/main/resources/lib/cluster-utils/run-on-datanode.ts
@@ -1,0 +1,72 @@
+import * as gridLib from '/lib/xp/grid';
+import { createOrUpdateSchedule } from '../scheduling/schedule-job';
+import { ClusterInfo, ClusterNodeInfo, requestClusterInfo } from './cluster-api';
+import { logger } from '../utils/logging';
+import { APP_DESCRIPTOR } from '../constants';
+
+const SHARED_MAP_KEY = 'main-datanode';
+
+const MAIN_DATANODE_NAME_KEY = 'datanode-name';
+
+const pickDatanode = (clusterInfo: ClusterInfo): ClusterNodeInfo | null => {
+    const datanode = clusterInfo.members.find((member) => member.isDataNode);
+    if (!datanode) {
+        logger.critical('No data nodes found!');
+        return null;
+    }
+
+    return datanode;
+};
+
+const isNodeInCluster = (clusterInfo: ClusterInfo, nodeName?: string): boolean => {
+    if (!nodeName) {
+        return false;
+    }
+
+    return !!clusterInfo.members.find((member) => member.name === nodeName);
+};
+
+export const refreshMainDatanode = () => {
+    const clusterInfo = requestClusterInfo();
+    if (!clusterInfo) {
+        logger.critical('Failed to get cluster info!');
+        return;
+    }
+
+    const sharedMap = gridLib.getMap(SHARED_MAP_KEY);
+    if (!sharedMap) {
+        logger.critical(`Shared map with key ${SHARED_MAP_KEY} is not available!`);
+        return;
+    }
+
+    const currentMainDatanode = sharedMap.get<string>(MAIN_DATANODE_NAME_KEY);
+    if (isNodeInCluster(clusterInfo, currentMainDatanode)) {
+        logger.info(
+            `Current main data node ${currentMainDatanode} is still valid, no action needed`
+        );
+        return;
+    }
+
+    const newMainDatanode = pickDatanode(clusterInfo);
+
+    sharedMap.set({
+        key: MAIN_DATANODE_NAME_KEY,
+        ttlSeconds: 0,
+        value: newMainDatanode,
+    });
+};
+
+export const initializeMainDatanodeSelection = () => {
+    refreshMainDatanode();
+
+    createOrUpdateSchedule({
+        jobName: 'refresh-main-datanode',
+        jobSchedule: {
+            type: 'CRON',
+            value: '* * * * *',
+            timeZone: 'GMT+2:00',
+        },
+        taskDescriptor: `${APP_DESCRIPTOR}:refresh-main-datanode`,
+        taskConfig: {},
+    });
+};

--- a/src/main/resources/lib/contentUpdate/content-update-listener.ts
+++ b/src/main/resources/lib/contentUpdate/content-update-listener.ts
@@ -1,17 +1,17 @@
 import * as eventLib from '/lib/xp/event';
 import * as contentLib from '/lib/xp/content';
-import * as clusterLib from '/lib/xp/cluster';
 import { runInContext } from '../context/run-in-context';
 import { CONTENT_REPO_PREFIX, CONTENT_ROOT_REPO_ID } from '../constants';
 import { transformFragmentCreatorToFragment } from '../content-transformers/fragment-creator';
 import { isContentLocalized } from '../localization/locale-utils';
 import { updateQbrickVideoContent } from './video-update';
 import { logger } from '../utils/logging';
+import { isMainDatanode } from '../cluster-utils/main-datanode';
 
 let hasContentUpdateListener = false;
 
 const handleEvent = (event: eventLib.EnonicEvent) => {
-    if (!clusterLib.isMaster()) {
+    if (!isMainDatanode()) {
         return;
     }
 

--- a/src/main/resources/lib/contentlists/remove-unpublished.ts
+++ b/src/main/resources/lib/contentlists/remove-unpublished.ts
@@ -1,13 +1,13 @@
 import * as contentLib from '/lib/xp/content';
 import { Content } from '/lib/xp/content';
 import * as eventLib from '/lib/xp/event';
-import * as clusterLib from '/lib/xp/cluster';
 import { runInContext } from '../context/run-in-context';
 import { isPrepublished } from '../scheduling/scheduled-publish';
 import { logger } from '../utils/logging';
 import { forceArray } from '../utils/array-utils';
 import { CONTENT_REPO_PREFIX } from '../constants';
 import { NavNoDescriptor } from '../../types/common';
+import { isMainDatanode } from '../cluster-utils/main-datanode';
 
 type ContentTypesWithContentLists = NavNoDescriptor<'content-list'> | NavNoDescriptor<'page-list'>;
 
@@ -132,7 +132,7 @@ export const activateContentListItemUnpublishedListener = () => {
     eventLib.listener({
         type: 'node.deleted',
         callback: (event) => {
-            if (!clusterLib.isMaster()) {
+            if (!isMainDatanode()) {
                 return;
             }
 

--- a/src/main/resources/lib/controllers/site-info-controller.ts
+++ b/src/main/resources/lib/controllers/site-info-controller.ts
@@ -3,7 +3,7 @@ import { Content } from '/lib/xp/content';
 import * as schedulerLib from '/lib/xp/scheduler';
 import httpClient from '/lib/http-client';
 import { URLS } from '../constants';
-import { clusterInfo, ClusterState, requestClusterInfo } from '../utils/cluster-utils';
+import { clusterInfo, ClusterState, requestClusterInfo } from '../cluster-utils/cluster-api';
 import { getPrepublishJobName, getUnpublishJobName } from '../scheduling/scheduled-publish';
 import { RepoBranch } from '../../types/common';
 import { hasValidCustomPath } from '../paths/custom-paths/custom-path-utils';

--- a/src/main/resources/lib/localization/layers-repo-utils/layers-repo-connection.ts
+++ b/src/main/resources/lib/localization/layers-repo-utils/layers-repo-connection.ts
@@ -1,14 +1,9 @@
 import * as nodeLib from '/lib/xp/node';
 import { RepoBranch } from '../../../types/common';
 import { getLayersData } from '../layers-data';
-import { logger } from '../../utils/logging';
 
 export const getLayersMultiConnection = (branch: RepoBranch) => {
-    const sources = getLayersData().sources[branch];
-
-    logger.info(`Sources for branch ${branch}: ${JSON.stringify(sources)}`);
-
     return nodeLib.multiRepoConnect({
-        sources,
+        sources: getLayersData().sources[branch],
     });
 };

--- a/src/main/resources/lib/localization/layers-repo-utils/query-all-layers.ts
+++ b/src/main/resources/lib/localization/layers-repo-utils/query-all-layers.ts
@@ -41,11 +41,6 @@ export function queryAllLayersToRepoIdBuckets({
             query: insertArchiveExcludedQueryString(queryParams.query),
         },
     });
-
-    logger.info(
-        `Hits for multirepo layers query: ${multiRepoQueryResult.hits.length} ${multiRepoQueryResult.total}`
-    );
-
     return resolveContent
         ? sortMultiRepoNodeHitsToBuckets({
               hits: multiRepoQueryResult.hits,

--- a/src/main/resources/lib/localization/publish-events.ts
+++ b/src/main/resources/lib/localization/publish-events.ts
@@ -1,11 +1,11 @@
 import * as eventLib from '/lib/xp/event';
 import { EnonicEvent, EnonicEventData } from '/lib/xp/event';
-import * as clusterLib from '/lib/xp/cluster';
 import { getRepoConnection } from '../utils/repo-utils';
 import { logger } from '../utils/logging';
 import { isContentLocalized } from './locale-utils';
 import { CONTENT_REPO_PREFIX, CONTENT_ROOT_REPO_ID } from '../constants';
 import { getContentFromAllLayers } from './layers-repo-utils/get-content-from-all-layers';
+import { isMainDatanode } from '../cluster-utils/main-datanode';
 
 let hasSetupListeners = false;
 
@@ -95,7 +95,7 @@ const pushToMasterIfContentIsPublishedInRootRepo = ({ id, repo, branch }: NodeDa
 // Publish/unpublish actions in the root layer should be propagated to non-localized content in
 // child layers, as XP does not do this automatically
 const propagatePublishEventsToLayers = (event: EnonicEvent) => {
-    if (!clusterLib.isMaster()) {
+    if (!isMainDatanode()) {
         return;
     }
 

--- a/src/main/resources/lib/paths/custom-paths/custom-path-event-listeners.ts
+++ b/src/main/resources/lib/paths/custom-paths/custom-path-event-listeners.ts
@@ -1,12 +1,12 @@
 import * as eventLib from '/lib/xp/event';
 import { EnonicEvent } from '/lib/xp/event';
-import * as clusterLib from '/lib/xp/cluster';
 import { RepoConnection } from '/lib/xp/node';
 import { hasInvalidCustomPath, hasValidCustomPath } from './custom-path-utils';
 import { logger } from '../../utils/logging';
 import { getLayersData } from '../../localization/layers-data';
 import { isContentLocalized } from '../../localization/locale-utils';
 import { getRepoConnection } from '../../utils/repo-utils';
+import { isMainDatanode } from '../../cluster-utils/main-datanode';
 
 const removeCustomPath = (contentId: string, repoConnection: RepoConnection) => {
     repoConnection.modify<{ data: { customPath?: string } }>({
@@ -22,7 +22,7 @@ const removeCustomPath = (contentId: string, repoConnection: RepoConnection) => 
 // When a content is duplicated, we don't want the custom path
 // to be duplicated as well, as it must be unique
 const removeCustomPathOnDuplicate = (event: EnonicEvent) => {
-    if (!clusterLib.isMaster()) {
+    if (!isMainDatanode()) {
         return;
     }
 
@@ -52,7 +52,7 @@ const removeCustomPathOnDuplicate = (event: EnonicEvent) => {
 };
 
 const removeInvalidCustomPathOnPublish = (event: EnonicEvent) => {
-    if (!clusterLib.isMaster()) {
+    if (!isMainDatanode()) {
         return;
     }
 

--- a/src/main/resources/lib/scheduling/scheduled-publish-updater.ts
+++ b/src/main/resources/lib/scheduling/scheduled-publish-updater.ts
@@ -1,4 +1,3 @@
-import * as clusterLib from '/lib/xp/cluster';
 import * as schedulerLib from '/lib/xp/scheduler';
 import {
     getPrepublishJobName,
@@ -7,7 +6,6 @@ import {
     scheduleUnpublish,
 } from './scheduled-publish';
 import { logger } from '../utils/logging';
-import { getLayersData } from '../localization/layers-data';
 import { queryAllLayersToRepoIdBuckets } from '../localization/layers-repo-utils/query-all-layers';
 
 const schedulePrepublishTasks = () => {
@@ -63,8 +61,6 @@ const scheduleUnpublishTasks = () => {
             `Updating scheduled unpublish jobs for ${contentHits.length} items in repo ${repoId}`
         );
 
-        const { repoIdToLocaleMap } = getLayersData();
-
         contentHits.forEach((content) => {
             if (!content.publish?.to) {
                 return;
@@ -87,10 +83,6 @@ const scheduleUnpublishTasks = () => {
 };
 
 export const updateScheduledPublishJobs = () => {
-    if (clusterLib.isMaster()) {
-        schedulePrepublishTasks();
-        scheduleUnpublishTasks();
-    } else {
-        logger.warning('updateScheduledPublishJobs will only run on master');
-    }
+    schedulePrepublishTasks();
+    scheduleUnpublishTasks();
 };

--- a/src/main/resources/lib/search/config.ts
+++ b/src/main/resources/lib/search/config.ts
@@ -1,12 +1,12 @@
 import * as contentLib from '/lib/xp/content';
 import { Content } from '/lib/xp/content';
-import * as clusterLib from '/lib/xp/cluster';
 import { RepoConnection } from '/lib/xp/node';
 import { logger } from '../utils/logging';
 import { runInContext } from '../context/run-in-context';
 import { getSearchRepoConnection, SEARCH_REPO_CONFIG_NODE } from './search-utils';
 import { SearchConfigData, SearchConfigDescriptor } from '../../types/content-types/search-config';
 import { forceArray } from '../utils/array-utils';
+import { isMainDatanode } from '../cluster-utils/main-datanode';
 
 type SearchConfig = Content<SearchConfigDescriptor>;
 type PersistedSearchConfig = { config?: SearchConfig };
@@ -173,7 +173,7 @@ export const revalidateSearchConfigCache = () => {
     logger.info('Updated search config');
     searchConfig = newSearchConfig;
 
-    if (clusterLib.isMaster()) {
+    if (isMainDatanode()) {
         persistValidConfig(searchConfig, searchRepoConnection);
     }
 

--- a/src/main/resources/lib/search/external/config.ts
+++ b/src/main/resources/lib/search/external/config.ts
@@ -1,6 +1,5 @@
 import * as contentLib from '/lib/xp/content';
 import { Content } from '/lib/xp/content';
-import * as clusterLib from '/lib/xp/cluster';
 import { RepoConnection } from '/lib/xp/node';
 import { logger } from '../../utils/logging';
 import { runInContext } from '../../context/run-in-context';
@@ -8,6 +7,7 @@ import { getSearchRepoConnection, SEARCH_REPO_EXTERNAL_CONFIG_NODE } from '../se
 import { forceArray } from '../../utils/array-utils';
 import { getRepoConnection } from '../../utils/repo-utils';
 import { CONTENT_ROOT_REPO_ID } from '../../constants';
+import { isMainDatanode } from '../../cluster-utils/main-datanode';
 
 type SearchConfig = Content<'no.nav.navno:search-config-v2'>;
 type PersistedSearchConfig = { config?: SearchConfig };
@@ -117,7 +117,7 @@ export const revalidateExternalSearchConfigCache = () => {
 
     searchConfig = newSearchConfig;
 
-    if (clusterLib.isMaster()) {
+    if (isMainDatanode()) {
         persistValidConfig(searchConfig, searchRepoConnection);
     }
 

--- a/src/main/resources/lib/search/external/event-handlers.ts
+++ b/src/main/resources/lib/search/external/event-handlers.ts
@@ -1,5 +1,4 @@
 import * as eventLib from '/lib/xp/event';
-import * as clusterLib from '/lib/xp/cluster';
 import * as taskLib from '/lib/xp/task';
 import { CONTENT_ROOT_PATH } from '/lib/xp/content';
 import { logger } from '../../utils/logging';

--- a/src/main/resources/lib/search/external/event-handlers.ts
+++ b/src/main/resources/lib/search/external/event-handlers.ts
@@ -7,6 +7,7 @@ import { CONTENT_ROOT_REPO_ID, URLS } from '../../constants';
 import { getLayersData } from '../../localization/layers-data';
 import { getExternalSearchConfig, revalidateExternalSearchConfigCache } from './config';
 import { updateExternalSearchDocumentForContent } from './update-one';
+import { isMainDatanode } from '../../cluster-utils/main-datanode';
 
 let isActive = false;
 
@@ -45,7 +46,7 @@ export const activateExternalSearchIndexEventHandlers = () => {
     eventLib.listener({
         type: '(node.pushed|node.deleted)',
         callback: (event) => {
-            if (!clusterLib.isMaster()) {
+            if (!isMainDatanode()) {
                 return;
             }
 

--- a/src/main/resources/lib/search/search-event-handlers.ts
+++ b/src/main/resources/lib/search/search-event-handlers.ts
@@ -1,5 +1,4 @@
 import * as eventLib from '/lib/xp/event';
-import * as clusterLib from '/lib/xp/cluster';
 import * as taskLib from '/lib/xp/task';
 import { getSearchConfig, revalidateSearchConfigCache } from './config';
 import { logger } from '../utils/logging';
@@ -15,6 +14,7 @@ import {
 import { getLayersData } from '../localization/layers-data';
 import { forceArray } from '../utils/array-utils';
 import { customListenerType } from '../utils/events';
+import { isMainDatanode } from '../cluster-utils/main-datanode';
 
 let isActive = false;
 let isRunningConfigUpdate = false;
@@ -112,14 +112,14 @@ export const activateSearchIndexEventHandlers = () => {
 
     revalidateSearchConfigCache();
 
-    if (clusterLib.isMaster()) {
+    if (isMainDatanode()) {
         runQueuedUpdates();
     }
 
     eventLib.listener({
         type: '(node.pushed|node.deleted)',
         callback: (event) => {
-            if (!clusterLib.isMaster()) {
+            if (!isMainDatanode()) {
                 return;
             }
 

--- a/src/main/resources/lib/sitemap/sitemap.ts
+++ b/src/main/resources/lib/sitemap/sitemap.ts
@@ -16,6 +16,7 @@ import { getPublicPath } from '../paths/public-path';
 import { customListenerType } from '../utils/events';
 import { forceArray, iterableToArray } from '../utils/array-utils';
 import { clusterInfo } from '../cluster-utils/cluster-api';
+import { isMainDatanode } from '../cluster-utils/main-datanode';
 
 const MAX_COUNT = 50000;
 const EVENT_TYPE_SITEMAP_GENERATED = 'sitemap-generated';
@@ -207,8 +208,8 @@ export const getAllSitemapEntries = () => {
 };
 
 const generateAndBroadcastSitemapData = () => {
-    if (clusterInfo?.localServerName !== 'a30apvl00087' || isGenerating) {
-        logger.info(`Skipping sitemap generation on ${clusterInfo?.localServerName}`);
+    if (!isMainDatanode() || isGenerating) {
+        logger.info(`Skipping sitemap generation on ${clusterInfo.localServerName}`);
         return;
     }
 
@@ -248,10 +249,6 @@ const generateAndBroadcastSitemapData = () => {
 
 export const generateSitemapDataAndActivateSchedule = () => {
     generateAndBroadcastSitemapData();
-
-    if (!clusterLib.isMaster()) {
-        return;
-    }
 
     // Regenerate sitemap from scratch at 06:00 daily
     createOrUpdateSchedule({

--- a/src/main/resources/lib/sitemap/sitemap.ts
+++ b/src/main/resources/lib/sitemap/sitemap.ts
@@ -2,8 +2,6 @@ import * as contentLib from '/lib/xp/content';
 import { Content } from '/lib/xp/content';
 import * as taskLib from '/lib/xp/task';
 import * as eventLib from '/lib/xp/event';
-import * as clusterLib from '/lib/xp/cluster';
-import { runInContext } from '../context/run-in-context';
 import { URLS } from '../constants';
 import { createOrUpdateSchedule } from '../scheduling/schedule-job';
 import { contentTypesInSitemap } from '../contenttype-lists';

--- a/src/main/resources/lib/sitemap/sitemap.ts
+++ b/src/main/resources/lib/sitemap/sitemap.ts
@@ -143,8 +143,6 @@ const updateSitemapEntry = (contentId: string, locale: string) =>
         }
     });
 
-export let sitemapRawEntries: SitemapEntry[] = [];
-
 const generateSitemapEntries = (): SitemapEntry[] => {
     const repoIdContentBuckets = queryAllLayersToRepoIdBuckets({
         branch: 'master',
@@ -277,13 +275,11 @@ const updateSitemapData = (entries: SitemapEntry[]) => {
         return;
     }
 
-    sitemapRawEntries = entries;
-
     const sitemapEntriesMapNew = new Map<string, SitemapEntry>();
 
     entries.forEach((entry) => {
         if (sitemapEntriesMapNew.has(entry._key)) {
-            logger.info(`Duplicate entry for sitemap data: ${JSON.stringify(entry)}`);
+            logger.warning(`Duplicate entry for sitemap data: ${JSON.stringify(entry)}`);
         } else {
             sitemapEntriesMapNew.set(entry._key, entry);
         }

--- a/src/main/resources/main.ts
+++ b/src/main/resources/main.ts
@@ -21,7 +21,7 @@ import { initLayersData } from './lib/localization/layers-data';
 import { activateLayersEventListeners } from './lib/localization/publish-events';
 import { activateContentUpdateListener } from './lib/contentUpdate/content-update-listener';
 import { activateExternalSearchIndexEventHandlers } from './lib/search/external/event-handlers';
-import { initializeMainDatanodeSelection } from './lib/cluster-utils/run-on-datanode';
+import { initializeMainDatanodeSelection } from './lib/cluster-utils/main-datanode';
 
 updateClusterInfo();
 initLayersData();
@@ -47,9 +47,9 @@ if (clusterLib.isMaster()) {
 
     // This is somewhat annoying for local development, as it will run a fairly heavy task and spam
     // the logs when generating the sitemap. This happens on every redeploy of the app.
-    if (app.config.env !== 'localhost') {
-        generateSitemapDataAndActivateSchedule();
-    }
+    // if (app.config.env !== 'localhost') {
+    generateSitemapDataAndActivateSchedule();
+    // }
 }
 
 log.info('Finished running main');

--- a/src/main/resources/main.ts
+++ b/src/main/resources/main.ts
@@ -25,7 +25,17 @@ import { initializeMainDatanodeSelection } from './lib/cluster-utils/main-datano
 
 updateClusterInfo();
 initLayersData();
+hookLibsWithTimeTravel();
 
+if (clusterLib.isMaster()) {
+    log.info('Running master only init scripts');
+    initializeMainDatanodeSelection();
+    initSearchRepo();
+}
+
+createOfficeBranchFetchSchedule();
+startOfficeInfoPeriodicUpdateSchedule();
+startFailsafeSchedule();
 activateLayersEventListeners();
 activateCacheEventListeners();
 activateSitemapDataUpdateEventListener();
@@ -34,17 +44,6 @@ activateCustomPathNodeListeners();
 activateSearchIndexEventHandlers();
 activateExternalSearchIndexEventHandlers();
 activateContentUpdateListener();
-
-hookLibsWithTimeTravel();
-
-if (clusterLib.isMaster()) {
-    log.info('Running master only init scripts');
-    initializeMainDatanodeSelection();
-    initSearchRepo();
-    startFailsafeSchedule();
-    startOfficeInfoPeriodicUpdateSchedule();
-    createOfficeBranchFetchSchedule();
-}
 
 // This is somewhat annoying for local development, as it will run a fairly heavy task and spam
 // the logs when generating the sitemap. This happens on every redeploy of the app.

--- a/src/main/resources/main.ts
+++ b/src/main/resources/main.ts
@@ -8,7 +8,7 @@ import {
     activateSitemapDataUpdateEventListener,
     generateSitemapDataAndActivateSchedule,
 } from './lib/sitemap/sitemap';
-import { updateClusterInfo } from './lib/utils/cluster-utils';
+import { updateClusterInfo } from './lib/cluster-utils/cluster-api';
 import { startOfficeInfoPeriodicUpdateSchedule } from './lib/officeInformation';
 import { activateContentListItemUnpublishedListener } from './lib/contentlists/remove-unpublished';
 import { startFailsafeSchedule } from './lib/scheduling/scheduler-failsafe';
@@ -21,6 +21,7 @@ import { initLayersData } from './lib/localization/layers-data';
 import { activateLayersEventListeners } from './lib/localization/publish-events';
 import { activateContentUpdateListener } from './lib/contentUpdate/content-update-listener';
 import { activateExternalSearchIndexEventHandlers } from './lib/search/external/event-handlers';
+import { initializeMainDatanodeSelection } from './lib/cluster-utils/run-on-datanode';
 
 updateClusterInfo();
 initLayersData();
@@ -38,6 +39,7 @@ hookLibsWithTimeTravel();
 
 if (clusterLib.isMaster()) {
     log.info('Running master only init scripts');
+    initializeMainDatanodeSelection();
     initSearchRepo();
     startFailsafeSchedule();
     startOfficeInfoPeriodicUpdateSchedule();

--- a/src/main/resources/main.ts
+++ b/src/main/resources/main.ts
@@ -44,12 +44,12 @@ if (clusterLib.isMaster()) {
     startFailsafeSchedule();
     startOfficeInfoPeriodicUpdateSchedule();
     createOfficeBranchFetchSchedule();
+}
 
-    // This is somewhat annoying for local development, as it will run a fairly heavy task and spam
-    // the logs when generating the sitemap. This happens on every redeploy of the app.
-    // if (app.config.env !== 'localhost') {
+// This is somewhat annoying for local development, as it will run a fairly heavy task and spam
+// the logs when generating the sitemap. This happens on every redeploy of the app.
+if (app.config.env !== 'localhost') {
     generateSitemapDataAndActivateSchedule();
-    // }
 }
 
 log.info('Finished running main');

--- a/src/main/resources/services/sitemap/sitemap.ts
+++ b/src/main/resources/services/sitemap/sitemap.ts
@@ -1,8 +1,4 @@
-import {
-    getAllSitemapEntries,
-    requestSitemapUpdate,
-    sitemapRawEntries,
-} from '../../lib/sitemap/sitemap';
+import { getAllSitemapEntries, requestSitemapUpdate } from '../../lib/sitemap/sitemap';
 import { logger } from '../../lib/utils/logging';
 import { validateServiceSecretHeader } from '../../lib/utils/auth-utils';
 
@@ -13,16 +9,6 @@ export const get = (req: XP.Request) => {
             body: {
                 message: 'Unauthorized',
             },
-            contentType: 'application/json',
-        };
-    }
-
-    const { queryResponse } = req.params;
-
-    if (typeof queryResponse === 'string') {
-        return {
-            status: 200,
-            body: sitemapRawEntries,
             contentType: 'application/json',
         };
     }

--- a/src/main/resources/tasks/refresh-main-datanode/refresh-main-datanode.ts
+++ b/src/main/resources/tasks/refresh-main-datanode/refresh-main-datanode.ts
@@ -1,4 +1,4 @@
-import { refreshMainDatanode } from '../../lib/cluster-utils/run-on-datanode';
+import { refreshMainDatanode } from '../../lib/cluster-utils/main-datanode';
 
 export const run = () => {
     refreshMainDatanode();

--- a/src/main/resources/tasks/refresh-main-datanode/refresh-main-datanode.ts
+++ b/src/main/resources/tasks/refresh-main-datanode/refresh-main-datanode.ts
@@ -1,0 +1,5 @@
+import { refreshMainDatanode } from '../../lib/cluster-utils/run-on-datanode';
+
+export const run = () => {
+    refreshMainDatanode();
+};

--- a/src/main/resources/tasks/refresh-main-datanode/refresh-main-datanode.xml
+++ b/src/main/resources/tasks/refresh-main-datanode/refresh-main-datanode.xml
@@ -1,0 +1,3 @@
+<task>
+    <description>Refresh current main datanode</description>
+</task>

--- a/src/main/resources/types/xp-libs/grid.d.ts
+++ b/src/main/resources/types/xp-libs/grid.d.ts
@@ -1,0 +1,42 @@
+declare module '*/lib/xp/grid' {
+    type SharedMapValue =
+        | string
+        | number
+        | boolean
+        | Record<string, unknown>
+        | Array<unknown>
+        | null;
+
+    type SharedMapSetParams<Type extends SharedMapValue> = {
+        key: string;
+        ttlSeconds: number;
+        value: Type;
+    };
+
+    type SharedMapModifyParams<Type extends SharedMapValue> = {
+        key: string;
+        ttlSeconds: number;
+        func: (oldValue: Type) => Type;
+    };
+
+    interface SharedMap {
+        set<Type extends SharedMapValue = SharedMapValue>(params: SharedMapSetParams<Type>): void;
+
+        get<Type extends SharedMapValue = SharedMapValue>(key: string): Type;
+
+        delete(key: string): void;
+
+        modify<Type extends SharedMapValue = SharedMapValue>(
+            params: SharedMapModifyParams<Type>
+        ): Type;
+    }
+
+    namespace gridLib {
+        interface GridLibrary {
+            getMap(id: string): SharedMap;
+        }
+    }
+
+    const gridLib: gridLib.GridLibrary;
+    export = gridLib;
+}

--- a/src/main/resources/webapp/webapp.ts
+++ b/src/main/resources/webapp/webapp.ts
@@ -38,7 +38,7 @@ const validActions: ActionsMap = {
         callback: requestSitemapUpdate,
     },
     updatePrepublishJobs: {
-        description: 'Oppretter scheduler-jobs for prepublish/unpublish (må kjøres på master)',
+        description: 'Oppretter scheduler-jobs for prepublish/unpublish',
         callback: updateScheduledPublishJobs,
     },
     removeUnpublishedFromContentLists: {


### PR DESCRIPTION
Vi kjører i dag en del jobber kun på master noden, dersom jobben kun skal kjøres en gang, fremfor på alle nodene. Dette skaper visse problemer, se linked issue https://github.com/navikt/nav-enonicxp/issues/1941

Setter derfor opp en mekanisme som velger ut en enkelt **data** node som slike jobber kan kjøres på, basert på SharedMap data i clusteret. For jobber som utfører operasjoner på Elastic-databasen erstattes dagens `isMaster`-sjekker med en sjekk på `isMainDatanode`, slik at disse jobbene alltid kjøres på en data node.