### PR TITLE
Setter alltid sortTitle på locale fallback data

### DIFF
--- a/src/main/resources/lib/forms-overview/form-details-list-builder.ts
+++ b/src/main/resources/lib/forms-overview/form-details-list-builder.ts
@@ -123,7 +123,7 @@ const transformToContentWithFallbackData = (
                 return;
             }
 
-            fallbackDataMap[contentId] = data;
+            fallbackDataMap[contentId] = { ...data, sortTitle: data.sortTitle || data.title };
         });
     });
 


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Sørger for at det ikke brukes norsk sortTitle dersom denne ikke er satt i locale fallback data.