### PR TITLE
Midlertidig service for å sette igang migrering av language for office-branch

### DIFF
--- a/src/main/resources/lib/officeBranch/update.ts
+++ b/src/main/resources/lib/officeBranch/update.ts
@@ -81,6 +81,9 @@ const deleteContent = (contentRef: string) => {
 };
 
 const getOfficeBranchLanguage = (office: OfficeBranchData) => {
+    if (office.brukerkontakt?.skriftspraak?.toLowerCase() === 'nb') {
+        return CONTENT_LOCALE_DEFAULT;
+    }
     return office.brukerkontakt?.skriftspraak?.toLowerCase() || CONTENT_LOCALE_DEFAULT;
 };
 

--- a/src/main/resources/services/officeBranchLanguageMigration/officeBranchLanguageMigration.ts
+++ b/src/main/resources/services/officeBranchLanguageMigration/officeBranchLanguageMigration.ts
@@ -1,0 +1,40 @@
+import * as contentLib from '/lib/xp/content';
+import { runInContext } from '../../lib/context/run-in-context';
+
+import { APP_DESCRIPTOR } from '../../lib/constants';
+
+const getOfficeInfo = () => {
+    const officeBranches = contentLib.query({
+        start: 0,
+        count: 1000,
+        contentTypes: [`${APP_DESCRIPTOR}:office-branch`],
+        query: `language = "nb"`,
+    }).hits;
+
+    officeBranches.forEach((officeBranch) => {
+        contentLib.modify({
+            key: officeBranch._id,
+            editor: (content) => ({
+                ...content,
+                language: 'no',
+            }),
+        });
+    });
+
+    contentLib.publish({
+        keys: officeBranches.map((officeBranch) => officeBranch._id),
+        sourceBranch: 'draft',
+        targetBranch: 'master',
+        includeDependencies: false,
+    });
+};
+
+export const get = () => {
+    runInContext({ branch: 'draft', asAdmin: true }, () => {
+        getOfficeInfo();
+    });
+    return {
+        status: 202,
+        contentType: 'application/json',
+    };
+};

--- a/src/main/resources/services/officeBranchLanguageMigration/officeBranchLanguageMigration.ts
+++ b/src/main/resources/services/officeBranchLanguageMigration/officeBranchLanguageMigration.ts
@@ -19,13 +19,13 @@ const getOfficeInfo = () => {
                 language: 'no',
             }),
         });
-    });
 
-    contentLib.publish({
-        keys: officeBranches.map((officeBranch) => officeBranch._id),
-        sourceBranch: 'draft',
-        targetBranch: 'master',
-        includeDependencies: false,
+        contentLib.publish({
+            keys: [officeBranch._id],
+            sourceBranch: 'draft',
+            targetBranch: 'master',
+            includeDependencies: false,
+        });
     });
 };
 


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Language for office-branch settes til 'nb' for norsk bokmål ved import fra NORG, men det ser ut til at vi bruker kombinasjonen no og nn for henholdsvis norsk bokmål og nynorsk?

Jeg sletter tjenesten igjen så snart kontor-språk er migrert.

## Testing
Testet i både dev og q6
