### PR TITLE
Gjør referanse-søk mer presist for oversiktssider

### DIFF
--- a/src/main/resources/lib/reference-search/references-finder.ts
+++ b/src/main/resources/lib/reference-search/references-finder.ts
@@ -307,7 +307,7 @@ export class ReferencesFinder {
             {
                 hasValue: {
                     field: 'data.audience',
-                    values: forceArray(selectedAudience),
+                    values: [selectedAudience],
                 },
             },
         ];
@@ -336,29 +336,45 @@ export class ReferencesFinder {
             return [];
         }
 
+        const selectedProviderAudience =
+            selectedAudience === 'provider'
+                ? forceArray(content.data.audience.provider?._selected)
+                : null;
+
+        const mustRules = [
+            {
+                hasValue: {
+                    field: 'type',
+                    values: ['no.nav.navno:forms-overview'],
+                },
+            },
+            {
+                hasValue: {
+                    field: 'data.audience._selected',
+                    values: [selectedAudience],
+                },
+            },
+            {
+                hasValue: {
+                    field: 'language',
+                    values: [content.language],
+                },
+            },
+        ];
+
+        if (selectedProviderAudience) {
+            mustRules.push({
+                hasValue: {
+                    field: 'data.audience.provider._selected',
+                    values: selectedProviderAudience,
+                },
+            });
+        }
+
         const result = this.contentNodeQuery({
             filters: {
                 boolean: {
-                    must: [
-                        {
-                            hasValue: {
-                                field: 'type',
-                                values: ['no.nav.navno:forms-overview'],
-                            },
-                        },
-                        {
-                            hasValue: {
-                                field: 'data.audience._selected',
-                                values: [selectedAudience],
-                            },
-                        },
-                        {
-                            hasValue: {
-                                field: 'language',
-                                values: [content.language],
-                            },
-                        },
-                    ],
+                    must: mustRules,
                 },
             },
         });

--- a/src/main/resources/lib/reference-search/references-finder.ts
+++ b/src/main/resources/lib/reference-search/references-finder.ts
@@ -335,7 +335,7 @@ export class ReferencesFinder {
             return [];
         }
 
-        const selectedAudience = content.data?.audience?._selected;
+        const selectedAudience = content.data.audience?._selected;
         if (!selectedAudience) {
             return [];
         }

--- a/src/main/resources/lib/reference-search/references-finder.ts
+++ b/src/main/resources/lib/reference-search/references-finder.ts
@@ -331,6 +331,10 @@ export class ReferencesFinder {
             return [];
         }
 
+        if (!content.data.formDetailsTargets) {
+            return [];
+        }
+
         const selectedAudience = content.data?.audience?._selected;
         if (!selectedAudience) {
             return [];

--- a/src/main/resources/lib/reference-search/references-finder.ts
+++ b/src/main/resources/lib/reference-search/references-finder.ts
@@ -340,11 +340,6 @@ export class ReferencesFinder {
             return [];
         }
 
-        const selectedProviderAudience =
-            selectedAudience === 'provider'
-                ? forceArray(content.data.audience.provider?._selected)
-                : null;
-
         const mustRules = [
             {
                 hasValue: {
@@ -366,10 +361,19 @@ export class ReferencesFinder {
             },
         ];
 
+        const selectedProviderAudience =
+            selectedAudience === 'provider'
+                ? forceArray(content.data.audience.provider?.provider_audience)
+                : null;
+
         if (selectedProviderAudience) {
+            if (selectedProviderAudience.length === 0) {
+                return [];
+            }
+
             mustRules.push({
                 hasValue: {
-                    field: 'data.audience.provider._selected',
+                    field: 'data.audience.provider.pageType.overview.provider_audience',
                     values: selectedProviderAudience,
                 },
             });


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Kun sider med relevante produktdetaljer skal vises som å ha en avhengighet fra oversiktssider
- Kun sider med skjemadetaljer skal vises som å ha avhengigheter fra skjemaoversikter
- Tar høyde for underkategorier for samarbeidspartner ved referansesøk for skjemaoversikter