### PR TITLE
Bugfixes for CustomSelectors

### DIFF
--- a/src/main/resources/lib/paths/custom-paths/custom-path-utils.ts
+++ b/src/main/resources/lib/paths/custom-paths/custom-path-utils.ts
@@ -12,7 +12,7 @@ const validCustomPathPattern = new RegExp('^(/[0-9a-z-/]*[^/]|/)$');
 // For custom paths, we need the leading slash on the root path
 const stripPathPrefix = (path: string) => _stripPathPrefix(path) || '/';
 
-export const isValidCustomPath = (path?: string) =>
+export const isValidCustomPath = (path?: string): path is string =>
     typeof path === 'string' && validCustomPathPattern.test(path);
 
 export const hasValidCustomPath = (content: Content): content is ContentWithCustomPath => {

--- a/src/main/resources/services/contentSelector/contentSelector.ts
+++ b/src/main/resources/services/contentSelector/contentSelector.ts
@@ -2,11 +2,11 @@ import * as contentLib from '/lib/xp/content';
 import { Content } from '/lib/xp/content';
 import * as portalLib from '/lib/xp/portal';
 import { generateFulltextQuery } from '../../lib/utils/mixed-bag-of-utils';
-import { customSelectorHitWithLink } from '../service-utils';
+import { customSelectorHitWithLink, customSelectorParseSelectedIdsFromReq } from '../service-utils';
 import { logger } from '../../lib/utils/logging';
 import { ContentDescriptor } from '../../types/content-types/content-config';
 import { stripPathPrefix } from '../../lib/paths/path-utils';
-import { forceArray, parseJsonToArray, removeDuplicates } from '../../lib/utils/array-utils';
+import { parseJsonToArray, removeDuplicates } from '../../lib/utils/array-utils';
 import { getNestedValues } from '../../lib/utils/object-utils';
 
 type SelectorHit = XP.CustomSelectorServiceResponseHit;
@@ -100,7 +100,6 @@ const getHitsFromIds = (ids: string[]) =>
 export const get = (req: XP.Request) => {
     const {
         query: userQuery,
-        ids,
         contentTypes: contentTypesJson,
         selectorQuery,
         sort,
@@ -109,7 +108,7 @@ export const get = (req: XP.Request) => {
     const query = buildQuery(userQuery, selectorQuery);
     const contentTypes = parseContentTypes(contentTypesJson);
 
-    const hitsFromIds = getHitsFromIds(forceArray(ids));
+    const hitsFromIds = getHitsFromIds(customSelectorParseSelectedIdsFromReq(req));
     const hitsFromQuery = getHitsFromQuery(query, contentTypes || undefined, sort);
     const hits = removeDuplicates([...hitsFromIds, ...hitsFromQuery], (a, b) => a.id === b.id);
 

--- a/src/main/resources/services/customPathSelector/customPathSelector.ts
+++ b/src/main/resources/services/customPathSelector/customPathSelector.ts
@@ -9,12 +9,12 @@ import { FRONTEND_APP_NAME, NAVNO_ROOT_PATH, REDIRECTS_ROOT_PATH, URLS } from '.
 import { logger } from '../../lib/utils/logging';
 import { customSelectorErrorIcon, customSelectorWarningIcon } from '../custom-selector-icons';
 import { runInContext } from '../../lib/context/run-in-context';
-import { forceArray } from '../../lib/utils/array-utils';
 import {
     formIntermediateStepGenerateCustomPath,
     formIntermediateStepValidateCustomPath,
 } from '../../lib/paths/custom-paths/custom-path-special-types';
 import { RepoBranch } from '../../types/common';
+import { customSelectorParseSelectedIdsFromReq } from '../service-utils';
 
 type SpecialUrlType = 'formIntermediateStep';
 
@@ -62,9 +62,9 @@ const getResult = ({
     ids,
 }: {
     query?: string;
-    ids?: string | string[];
+    ids: string[];
 }): XP.CustomSelectorServiceResponseHit => {
-    const currentSelection = forceArray(ids)[0];
+    const currentSelection = ids[0];
     const suggestedPath = query || currentSelection;
 
     if (!isValidCustomPath(suggestedPath)) {
@@ -179,7 +179,9 @@ export const get = (req: XP.CustomSelectorServiceRequest): XP.CustomSelectorServ
         };
     }
 
-    const { query, ids, type } = req.params;
+    const { query, type } = req.params;
+
+    const ids = customSelectorParseSelectedIdsFromReq(req);
 
     const result = getResult({ query, ids });
 

--- a/src/main/resources/services/customPathSelector/customPathSelector.ts
+++ b/src/main/resources/services/customPathSelector/customPathSelector.ts
@@ -59,12 +59,11 @@ const findExistingContentsWithCustomPath = (suggestedCustomPath: string, branch:
 
 const getResult = ({
     query,
-    ids,
+    currentSelection,
 }: {
     query?: string;
-    ids: string[];
+    currentSelection?: string;
 }): XP.CustomSelectorServiceResponseHit => {
-    const currentSelection = ids[0];
     const suggestedPath = query || currentSelection;
 
     if (!isValidCustomPath(suggestedPath)) {
@@ -181,9 +180,9 @@ export const get = (req: XP.CustomSelectorServiceRequest): XP.CustomSelectorServ
 
     const { query, type } = req.params;
 
-    const ids = customSelectorParseSelectedIdsFromReq(req);
+    const currentSelection = customSelectorParseSelectedIdsFromReq(req)[0];
 
-    const result = getResult({ query, ids });
+    const result = getResult({ query, currentSelection });
 
     const validatedResult = validateResult(result, type as SpecialUrlType);
 

--- a/src/main/resources/services/globalValues/selector/selector.ts
+++ b/src/main/resources/services/globalValues/selector/selector.ts
@@ -11,7 +11,10 @@ import { generateFulltextQuery } from '../../../lib/utils/mixed-bag-of-utils';
 import { runInContext } from '../../../lib/context/run-in-context';
 import { GlobalValueItem, GlobalValueContentDescriptor } from '../../../lib/global-values/types';
 import { buildGlobalValuePreviewString } from '../../../lib/global-values/macro-preview';
-import { customSelectorHitWithLink } from '../../service-utils';
+import {
+    customSelectorHitWithLink,
+    customSelectorParseSelectedIdsFromReq,
+} from '../../service-utils';
 import { forceArray } from '../../../lib/utils/array-utils';
 
 type Hit = XP.CustomSelectorServiceResponseHit;
@@ -102,7 +105,8 @@ const getHitsFromSelectedIds = (ids: string | string[], withDescription?: boolea
     }, [] as Hit[]);
 
 export const globalValueSelectorService = (req: XP.Request) => {
-    const { query, ids, contentType } = req.params as ReqParams;
+    const { query, contentType } = req.params as ReqParams;
+    const ids = customSelectorParseSelectedIdsFromReq(req);
 
     const withDescription = req.params.withDescription === 'true';
 

--- a/src/main/resources/services/globalValues/selector/selector.ts
+++ b/src/main/resources/services/globalValues/selector/selector.ts
@@ -77,8 +77,8 @@ const getHitsFromQuery = (
         .sort((a, b) => (a.displayName.toLowerCase() > b.displayName.toLowerCase() ? 1 : -1));
 };
 
-const getHitsFromSelectedIds = (ids: string | string[], withDescription?: boolean) =>
-    forceArray(ids).reduce((acc, key) => {
+const getHitsFromSelectedIds = (ids: string[], withDescription?: boolean) =>
+    ids.reduce((acc, key) => {
         const { gvKey, contentId } = getGvKeyAndContentIdFromUniqueKey(key);
 
         if (!gvKey || !contentId) {
@@ -106,12 +106,13 @@ const getHitsFromSelectedIds = (ids: string | string[], withDescription?: boolea
 
 export const globalValueSelectorService = (req: XP.Request) => {
     const { query, contentType } = req.params as ReqParams;
+
     const ids = customSelectorParseSelectedIdsFromReq(req);
 
     const withDescription = req.params.withDescription === 'true';
 
     const hits = runInContext({ branch: 'master' }, () =>
-        ids
+        ids.length > 0
             ? getHitsFromSelectedIds(ids, withDescription)
             : getHitsFromQuery(contentType, query, withDescription)
     );

--- a/src/main/resources/services/htmlFragmentSelector/htmlFragmentSelector.ts
+++ b/src/main/resources/services/htmlFragmentSelector/htmlFragmentSelector.ts
@@ -4,9 +4,8 @@ import {
     appendMacroDescriptionToKey,
     getKeyWithoutMacroDescription,
 } from '../../lib/utils/component-utils';
-import { customSelectorHitWithLink } from '../service-utils';
+import { customSelectorHitWithLink, customSelectorParseSelectedIdsFromReq } from '../service-utils';
 import { runInContext } from '../../lib/context/run-in-context';
-import { forceArray } from '../../lib/utils/array-utils';
 
 type Hit = XP.CustomSelectorServiceResponseHit;
 
@@ -23,10 +22,11 @@ const hitFromFragment = (fragment: Content<'portal:fragment'>, withDescription?:
     );
 
 const getHitsForSelector = (req: XP.CustomSelectorServiceRequest) => {
-    const { query, withDescription, ids } = req.params;
+    const { query, withDescription } = req.params;
+    const ids = customSelectorParseSelectedIdsFromReq(req);
 
-    if (ids) {
-        return forceArray(ids).reduce<Hit[]>((acc, id) => {
+    if (ids.length > 0) {
+        return ids.reduce<Hit[]>((acc, id) => {
             const fragmentId = getKeyWithoutMacroDescription(id);
             const fragment = contentLib.get({ key: fragmentId });
 

--- a/src/main/resources/services/htmlFragmentSelector/htmlFragmentSelector.ts
+++ b/src/main/resources/services/htmlFragmentSelector/htmlFragmentSelector.ts
@@ -62,15 +62,13 @@ const getHitsFromQuery = (query?: string) =>
         })
         .hits.map((fragment) => hitFromFragment(fragment));
 
-const getHitsForSelector = (req: XP.CustomSelectorServiceRequest) => {
+export const get = (req: XP.CustomSelectorServiceRequest) => {
     const { query } = req.params;
     const ids = customSelectorParseSelectedIdsFromReq(req);
 
-    return ids.length > 0 ? getSelectedHits(ids) : getHitsFromQuery(query);
-};
-
-export const get = (req: XP.CustomSelectorServiceRequest) => {
-    const hits = runInContext({ branch: 'master' }, () => getHitsForSelector(req));
+    const hits = runInContext({ branch: 'master' }, () =>
+        ids.length > 0 ? getSelectedHits(ids) : getHitsFromQuery(query)
+    );
 
     return {
         status: 200,

--- a/src/main/resources/services/htmlFragmentSelector/htmlFragmentSelector.ts
+++ b/src/main/resources/services/htmlFragmentSelector/htmlFragmentSelector.ts
@@ -9,12 +9,12 @@ import { runInContext } from '../../lib/context/run-in-context';
 
 type Hit = XP.CustomSelectorServiceResponseHit;
 
-const hitFromFragment = (fragment: Content<'portal:fragment'>): Hit =>
+const hitFromFragment = (fragment: Content<'portal:fragment'>, id?: string): Hit =>
     customSelectorHitWithLink(
         {
             // We include the displayName in the macro id attribute to make it easier
             // to determine the selected fragment at a glance in the editor
-            id: appendMacroDescriptionToKey(fragment._id, fragment.displayName),
+            id: id || appendMacroDescriptionToKey(fragment._id, fragment.displayName),
             displayName: fragment.displayName,
             description: fragment._path,
         },
@@ -27,11 +27,8 @@ const getSelectedHits = (ids: string[]) =>
         const fragment = contentLib.get({ key: fragmentId });
 
         if (fragment?.type === 'portal:fragment') {
-            acc.push({
-                ...hitFromFragment(fragment),
-                // Keep the existing id, in case the displayName has changed on the fragment.
-                id,
-            });
+            // Keep the existing id, in case the displayName has changed on the fragment.
+            acc.push(hitFromFragment(fragment, id));
         }
 
         return acc;

--- a/src/main/resources/services/htmlFragmentSelector/htmlFragmentSelector.ts
+++ b/src/main/resources/services/htmlFragmentSelector/htmlFragmentSelector.ts
@@ -12,6 +12,8 @@ type Hit = XP.CustomSelectorServiceResponseHit;
 const hitFromFragment = (fragment: Content<'portal:fragment'>): Hit =>
     customSelectorHitWithLink(
         {
+            // We include the displayName in the macro id attribute to make it easier
+            // to determine the selected fragment at a glance in the editor
             id: appendMacroDescriptionToKey(fragment._id, fragment.displayName),
             displayName: fragment.displayName,
             description: fragment._path,
@@ -24,17 +26,15 @@ const getSelectedHits = (ids: string[]) =>
         const fragmentId = getKeyWithoutMacroDescription(id);
         const fragment = contentLib.get({ key: fragmentId });
 
-        if (!fragment || fragment.type !== 'portal:fragment') {
-            return acc;
+        if (fragment?.type === 'portal:fragment') {
+            acc.push({
+                ...hitFromFragment(fragment),
+                // Keep the existing id, in case the displayName has changed on the fragment.
+                id,
+            });
         }
 
-        return [
-            ...acc,
-            {
-                ...hitFromFragment(fragment),
-                id,
-            },
-        ];
+        return acc;
     }, []);
 
 const getHitsFromQuery = (query?: string) =>

--- a/src/main/resources/services/productDetailsSelector/productDetailsSelector.ts
+++ b/src/main/resources/services/productDetailsSelector/productDetailsSelector.ts
@@ -3,7 +3,7 @@ import * as portalLib from '/lib/xp/portal';
 import { Content } from '/lib/xp/content';
 import { ProductDetails } from '../../site/content-types/product-details/product-details';
 import { generateFulltextQuery } from '../../lib/utils/mixed-bag-of-utils';
-import { customSelectorHitWithLink } from '../service-utils';
+import { customSelectorHitWithLink, customSelectorParseSelectedIdsFromReq } from '../service-utils';
 import { customSelectorErrorIcon } from '../custom-selector-icons';
 import { stripPathPrefix } from '../../lib/paths/path-utils';
 import { runInLocaleContext } from '../../lib/localization/locale-context';
@@ -107,12 +107,13 @@ const getHitsFromQuery = (
 };
 
 const selectorHandler = (req: XP.Request) => {
-    const { detailType, query, ids } = req.params as SelectorParams;
+    const { detailType, query } = req.params as SelectorParams;
+    const selectedId = customSelectorParseSelectedIdsFromReq(req)[0];
 
     const { language } = portalLib.getContent();
 
-    const hits = ids
-        ? [getSelectedHit(ids, detailType, language)]
+    const hits = selectedId
+        ? [getSelectedHit(selectedId, detailType, language)]
         : getHitsFromQuery(detailType, language, query);
 
     return {

--- a/src/main/resources/services/service-utils.ts
+++ b/src/main/resources/services/service-utils.ts
@@ -1,5 +1,6 @@
 import { customSelectorEditIcon } from './custom-selector-icons';
 import { buildEditorPathFromContext } from '../lib/paths/editor-path';
+import { logger } from '../lib/utils/logging';
 
 const getServiceName = (req: XP.Request) => req.contextPath.split('/').slice(-1)[0];
 
@@ -31,4 +32,13 @@ export const customSelectorHitWithLink = (
             type: hit.icon?.type || customSelectorEditIcon.type,
         },
     };
+};
+
+export const customSelectorParseSelectedIdsFromReq = (req: XP.Request): string[] => {
+    const { ids } = req.params;
+    if (!ids) {
+        return [];
+    }
+
+    return Array.isArray(ids) ? ids : ids.split(',');
 };

--- a/src/main/resources/site/content-types/calculator/calculator.xml
+++ b/src/main/resources/site/content-types/calculator/calculator.xml
@@ -61,7 +61,7 @@
                             <occurrences minimum="1" maximum="1"/>
                             <config>
                                 <service>globalValues</service>
-                                <param value="valueType">numberValue</param>
+                                <param value="contentType">no.nav.navno:global-value-set</param>
                             </config>
                         </input>
                         <input name="variableName" type="TextLine">

--- a/src/main/resources/site/content-types/forms-overview/forms-overview.xml
+++ b/src/main/resources/site/content-types/forms-overview/forms-overview.xml
@@ -126,7 +126,7 @@
                         <service>contentSelector</service>
                         <!-- Don't add linebreaks/whitespace to the param body values, as these will be included in the service calls -_- -->
                         <param value="contentTypes">["no.nav.navno:content-page-with-sidemenus","no.nav.navno:guide-page"]</param>
-                        <param value="selectorQuery">language="{language}" AND data.audience._selected="{data.audience._selected}" AND data.formDetailsTargets LIKE "*"</param>
+                        <param value="selectorQuery">data.audience._selected="{data.audience._selected}" AND data.formDetailsTargets LIKE "*"</param>
                         <param value="sort">data.area ASC, displayName ASC</param>
                     </config>
                 </input>

--- a/src/main/resources/site/macros/global-value-with-math/global-value-with-math.xml
+++ b/src/main/resources/site/macros/global-value-with-math/global-value-with-math.xml
@@ -7,7 +7,7 @@
             <occurrences minimum="0" maximum="0"/>
             <config>
                 <service>globalValues</service>
-                <param value="valueType">numberValue</param>
+                <param value="contentType">no.nav.navno:global-value-set</param>
                 <param value="withDescription">true</param>
             </config>
         </input>

--- a/src/main/resources/site/macros/html-fragment/html-fragment.xml
+++ b/src/main/resources/site/macros/html-fragment/html-fragment.xml
@@ -8,7 +8,6 @@
             <occurrences minimum="1" maximum="1"/>
             <config>
                 <service>htmlFragmentSelector</service>
-                <param value="withDescription">true</param>
             </config>
         </input>
     </form>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Fikser parsing av ids-parameteret i customselectors. Dette var tidligere et array, nå er det visst bare en komma-separert string-liste.
- Fikser bug som gjorde at saksbehandlingstider kunne velges for utregninger med globale variabler
- Fjerner språkrestriksjon på valg av ekskludert innhold på skjemaoversikter, slik at ikke-lokaliserte sider også kan ekskluderes
- Fjerner parameteret `withDescription` fra htmlFragmentSelector, ettersom denne alltid er true