### PR TITLE
Bugfixes for redirect-responser til frontend

### DIFF
--- a/src/main/resources/lib/cache/find-paths-to-invalidate.ts
+++ b/src/main/resources/lib/cache/find-paths-to-invalidate.ts
@@ -1,7 +1,7 @@
 import { getNodeVersions } from '../utils/version-utils';
 import { isPublicRenderedType, NodeEventData } from './utils';
 import { getCustomPathFromContent } from '../paths/custom-paths/custom-path-utils';
-import { stripPathPrefix } from '../paths/path-utils';
+import { stripPathPrefix, stripRedirectsPathPrefix } from '../paths/path-utils';
 import { getPublicPath } from '../paths/public-path';
 import { getLayersData } from '../localization/layers-data';
 import { ReferencesFinder } from '../reference-search/references-finder';
@@ -113,7 +113,7 @@ const getNodePaths = (contentId: string, repoId: string, branch: RepoBranch) => 
     const internalPath = stripPathPrefix(baseContent._path);
     const changedPaths = findChangedPaths(contentId, repoId, baseContent._path);
 
-    return [internalPath, ...publicPaths, ...changedPaths];
+    return [internalPath, ...publicPaths, ...changedPaths].map(stripRedirectsPathPrefix);
 };
 
 export const findPathsToInvalidate = (nodeEventData: NodeEventData, eventType: string) => {

--- a/src/main/resources/lib/constants.ts
+++ b/src/main/resources/lib/constants.ts
@@ -65,7 +65,8 @@ export const CONTENT_LOCALE_DEFAULT = 'no';
 
 export const SEARCH_REPO_ID = 'nav.no.search';
 export const NAVNO_ROOT_PATH = '/www.nav.no';
-export const REDIRECTS_ROOT_PATH = `${NAVNO_ROOT_PATH}/redirects`;
+export const REDIRECTS_PATH = '/redirects';
+export const REDIRECTS_ROOT_PATH = `${NAVNO_ROOT_PATH}${REDIRECTS_PATH}`;
 export const FRONTEND_APP_NAME = 'nav-enonicxp-frontend';
 export const CONTENT_STUDIO_PATH_PREFIX = '/admin/tool/com.enonic.app.contentstudio/main';
 

--- a/src/main/resources/lib/paths/path-utils.ts
+++ b/src/main/resources/lib/paths/path-utils.ts
@@ -1,9 +1,13 @@
-import { NAVNO_ROOT_PATH } from '../constants';
-import { Content } from '/lib/xp/content';
+import { NAVNO_ROOT_PATH, REDIRECTS_PATH } from '../constants';
+import { Content, CONTENT_ROOT_PATH } from '/lib/xp/content';
 
 type ContentWithExternalProductUrl = Content & { data: { externalProductUrl: string } };
 
-const navnoRootPathFilter = new RegExp(`^(/content)?${NAVNO_ROOT_PATH}`);
+const navnoRootPathFilter = new RegExp(`^(${CONTENT_ROOT_PATH})?${NAVNO_ROOT_PATH}`);
+
+const redirectsPathFilter = new RegExp(
+    `^(${CONTENT_ROOT_PATH})?(${NAVNO_ROOT_PATH})?${REDIRECTS_PATH}`
+);
 
 export const stripPathPrefix = (path: string) => path.replace(navnoRootPathFilter, '');
 
@@ -13,3 +17,5 @@ export const hasExternalProductUrl = (
     content: Content | ContentWithExternalProductUrl
 ): content is ContentWithExternalProductUrl =>
     !!(content as ContentWithExternalProductUrl).data?.externalProductUrl;
+
+export const stripRedirectsPathPrefix = (path: string) => path.replace(redirectsPathFilter, '');

--- a/src/main/resources/services/sitecontent/public/public-response.ts
+++ b/src/main/resources/services/sitecontent/public/public-response.ts
@@ -38,7 +38,11 @@ const _sitecontentPublicResponse = ({
     });
 
     if (specialResponse) {
-        return specialResponse.response;
+        return (
+            specialResponse.response ||
+            // If the special response is null, we also want to check for any applicable redirect
+            sitecontentNotFoundRedirect({ pathRequested: idOrPath, branch: 'master' })
+        );
     }
 
     return sitecontentContentResponse({ baseContent: content, branch: 'master', locale });

--- a/src/main/resources/services/sitecontent/public/special-redirects.ts
+++ b/src/main/resources/services/sitecontent/public/special-redirects.ts
@@ -94,14 +94,14 @@ const getOfficeInfoRedirect = ({ content }: Args) => {
     // will return a 404 after redirect.
     const office = foundOfficeContent.hits[0];
 
-    return {
-        response: transformToRedirect({
+    return nullableResponse(
+        transformToRedirect({
             content,
             target: office._path,
             type: 'internal',
             isPermanent: true,
-        }),
-    };
+        })
+    );
 };
 
 const getLocaleRedirect = ({ content, locale, branch }: Args) => {
@@ -149,6 +149,9 @@ const getCustomPathRedirect = ({ content, requestedPath, branch, locale }: Args)
     );
 };
 
+// Should return null if there is no applicable special response
+// The NullableResponse may contain a null-value, indicating that the special response
+// should be 404
 export const sitecontentSpecialResponse = (args: Args): NullableResponse | null => {
     return (
         getPreviewOnlyResponse(args) ||

--- a/src/main/resources/services/sitecontent/public/special-redirects.ts
+++ b/src/main/resources/services/sitecontent/public/special-redirects.ts
@@ -150,7 +150,7 @@ const getCustomPathRedirect = ({ content, requestedPath, branch, locale }: Args)
 };
 
 // Should return null if there is no applicable special response
-// The NullableResponse may contain a null-value, indicating that the special response
+// The NullableResponse may itself contain a null-value, indicating that the special response
 // should be 404
 export const sitecontentSpecialResponse = (args: Args): NullableResponse | null => {
     return (

--- a/src/main/resources/services/sitecontentPaths/sitecontentPaths.ts
+++ b/src/main/resources/services/sitecontentPaths/sitecontentPaths.ts
@@ -9,7 +9,7 @@ import {
 } from '../../lib/contenttype-lists';
 import { logger } from '../../lib/utils/logging';
 import { validateServiceSecretHeader } from '../../lib/utils/auth-utils';
-import { stripPathPrefix } from '../../lib/paths/path-utils';
+import { stripPathPrefix, stripRedirectsPathPrefix } from '../../lib/paths/path-utils';
 import { getPublicPath } from '../../lib/paths/public-path';
 import { removeDuplicates } from '../../lib/utils/array-utils';
 import { buildLocalePath } from '../../lib/localization/locale-utils';
@@ -115,7 +115,7 @@ const getPathsToRender = (isTest?: boolean) => {
         count: 20000,
         contentTypes: linkContentTypes,
         query: `_path LIKE '${REDIRECTS_NODE_PATH}*'`,
-    }).hits.map((content) => content._path.replace(REDIRECTS_ROOT_PATH, ''));
+    }).hits.map((content) => stripRedirectsPathPrefix(content._path));
 
     return removeDuplicates([...contentPaths, ...redirectPaths]);
 };


### PR DESCRIPTION
- Sørger for at redirects fungerer for url'er som overlapper med innhold flagget som previewOnly
- Sørger for at cache for riktige paths i frontend invalideres når en redirect i /redirects-mappa endres