### PR TITLE
Reimplementerer gamle parts

### DIFF
--- a/src/main/resources/site/parts/breaking-news/breaking-news.ts
+++ b/src/main/resources/site/parts/breaking-news/breaking-news.ts
@@ -1,0 +1,3 @@
+import { componentPreviewController } from '../../../lib/controllers/component-preview-controller';
+
+export const get = componentPreviewController;

--- a/src/main/resources/site/parts/breaking-news/breaking-news.xml
+++ b/src/main/resources/site/parts/breaking-news/breaking-news.xml
@@ -1,0 +1,16 @@
+<part xmlns="urn:enonic:xp:model:1.0">
+    <display-name>breaking-news (legacy, ikke bruk!)</display-name>
+    <form></form>
+    <config>
+        <allow-on-content-type>${app}:large-table</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article-chapter</allow-on-content-type>
+        <allow-on-content-type>${app}:melding</allow-on-content-type>
+        <allow-on-content-type>${app}:office-information</allow-on-content-type>
+        <allow-on-content-type>${app}:page-list</allow-on-content-type>
+        <allow-on-content-type>${app}:publishing-calendar</allow-on-content-type>
+        <allow-on-content-type>${app}:section-page</allow-on-content-type>
+        <allow-on-content-type>${app}:transport-page</allow-on-content-type>
+        <allow-on-content-type>portal:page-template</allow-on-content-type>
+    </config>
+</part>

--- a/src/main/resources/site/parts/link-lists/link-lists.ts
+++ b/src/main/resources/site/parts/link-lists/link-lists.ts
@@ -1,0 +1,3 @@
+import { componentPreviewController } from '../../../lib/controllers/component-preview-controller';
+
+export const get = componentPreviewController;

--- a/src/main/resources/site/parts/link-lists/link-lists.xml
+++ b/src/main/resources/site/parts/link-lists/link-lists.xml
@@ -1,0 +1,16 @@
+<part xmlns="urn:enonic:xp:model:1.0">
+    <display-name>link-lists (legacy, ikke bruk!)</display-name>
+    <form></form>
+    <config>
+        <allow-on-content-type>${app}:large-table</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article-chapter</allow-on-content-type>
+        <allow-on-content-type>${app}:melding</allow-on-content-type>
+        <allow-on-content-type>${app}:office-information</allow-on-content-type>
+        <allow-on-content-type>${app}:page-list</allow-on-content-type>
+        <allow-on-content-type>${app}:publishing-calendar</allow-on-content-type>
+        <allow-on-content-type>${app}:section-page</allow-on-content-type>
+        <allow-on-content-type>${app}:transport-page</allow-on-content-type>
+        <allow-on-content-type>portal:page-template</allow-on-content-type>
+    </config>
+</part>

--- a/src/main/resources/site/parts/link-panels/link-panels.ts
+++ b/src/main/resources/site/parts/link-panels/link-panels.ts
@@ -1,0 +1,3 @@
+import { componentPreviewController } from '../../../lib/controllers/component-preview-controller';
+
+export const get = componentPreviewController;

--- a/src/main/resources/site/parts/link-panels/link-panels.xml
+++ b/src/main/resources/site/parts/link-panels/link-panels.xml
@@ -1,0 +1,16 @@
+<part xmlns="urn:enonic:xp:model:1.0">
+    <display-name>link-panels (legacy, ikke bruk!)</display-name>
+    <form></form>
+    <config>
+        <allow-on-content-type>${app}:large-table</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article-chapter</allow-on-content-type>
+        <allow-on-content-type>${app}:melding</allow-on-content-type>
+        <allow-on-content-type>${app}:office-information</allow-on-content-type>
+        <allow-on-content-type>${app}:page-list</allow-on-content-type>
+        <allow-on-content-type>${app}:publishing-calendar</allow-on-content-type>
+        <allow-on-content-type>${app}:section-page</allow-on-content-type>
+        <allow-on-content-type>${app}:transport-page</allow-on-content-type>
+        <allow-on-content-type>portal:page-template</allow-on-content-type>
+    </config>
+</part>

--- a/src/main/resources/site/parts/main-article-linked-list/main-article-linked-list.ts
+++ b/src/main/resources/site/parts/main-article-linked-list/main-article-linked-list.ts
@@ -1,0 +1,3 @@
+import { componentPreviewController } from '../../../lib/controllers/component-preview-controller';
+
+export const get = componentPreviewController;

--- a/src/main/resources/site/parts/main-article-linked-list/main-article-linked-list.xml
+++ b/src/main/resources/site/parts/main-article-linked-list/main-article-linked-list.xml
@@ -1,0 +1,15 @@
+<part xmlns="urn:enonic:xp:model:1.0">
+    <display-name>main-article-linked-list (legacy, ikke bruk!)</display-name>
+    <form></form>
+    <config>
+        <allow-on-content-type>${app}:large-table</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article-chapter</allow-on-content-type>
+        <allow-on-content-type>${app}:melding</allow-on-content-type>
+        <allow-on-content-type>${app}:office-information</allow-on-content-type>
+        <allow-on-content-type>${app}:page-list</allow-on-content-type>
+        <allow-on-content-type>${app}:publishing-calendar</allow-on-content-type>
+        <allow-on-content-type>${app}:section-page</allow-on-content-type>
+        <allow-on-content-type>portal:page-template</allow-on-content-type>
+    </config>
+</part>

--- a/src/main/resources/site/parts/main-article/main-article.ts
+++ b/src/main/resources/site/parts/main-article/main-article.ts
@@ -1,0 +1,3 @@
+import { componentPreviewController } from '../../../lib/controllers/component-preview-controller';
+
+export const get = componentPreviewController;

--- a/src/main/resources/site/parts/main-article/main-article.xml
+++ b/src/main/resources/site/parts/main-article/main-article.xml
@@ -1,0 +1,16 @@
+<part xmlns="urn:enonic:xp:model:1.0">
+    <display-name>main-article (legacy, ikke bruk!)</display-name>
+    <form></form>
+    <config>
+        <allow-on-content-type>${app}:large-table</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article-chapter</allow-on-content-type>
+        <allow-on-content-type>${app}:melding</allow-on-content-type>
+        <allow-on-content-type>${app}:office-information</allow-on-content-type>
+        <allow-on-content-type>${app}:page-list</allow-on-content-type>
+        <allow-on-content-type>${app}:publishing-calendar</allow-on-content-type>
+        <allow-on-content-type>${app}:section-page</allow-on-content-type>
+        <allow-on-content-type>${app}:transport-page</allow-on-content-type>
+        <allow-on-content-type>portal:page-template</allow-on-content-type>
+    </config>
+</part>

--- a/src/main/resources/site/parts/main-panels/main-panels.ts
+++ b/src/main/resources/site/parts/main-panels/main-panels.ts
@@ -1,0 +1,3 @@
+import { componentPreviewController } from '../../../lib/controllers/component-preview-controller';
+
+export const get = componentPreviewController;

--- a/src/main/resources/site/parts/main-panels/main-panels.xml
+++ b/src/main/resources/site/parts/main-panels/main-panels.xml
@@ -1,0 +1,16 @@
+<part xmlns="urn:enonic:xp:model:1.0">
+    <display-name>main-panels (legacy, ikke bruk!)</display-name>
+    <form></form>
+    <config>
+        <allow-on-content-type>${app}:large-table</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article-chapter</allow-on-content-type>
+        <allow-on-content-type>${app}:melding</allow-on-content-type>
+        <allow-on-content-type>${app}:office-information</allow-on-content-type>
+        <allow-on-content-type>${app}:page-list</allow-on-content-type>
+        <allow-on-content-type>${app}:publishing-calendar</allow-on-content-type>
+        <allow-on-content-type>${app}:section-page</allow-on-content-type>
+        <allow-on-content-type>${app}:transport-page</allow-on-content-type>
+        <allow-on-content-type>portal:page-template</allow-on-content-type>
+    </config>
+</part>

--- a/src/main/resources/site/parts/menu-list/menu-list.ts
+++ b/src/main/resources/site/parts/menu-list/menu-list.ts
@@ -1,0 +1,3 @@
+import { componentPreviewController } from '../../../lib/controllers/component-preview-controller';
+
+export const get = componentPreviewController;

--- a/src/main/resources/site/parts/menu-list/menu-list.xml
+++ b/src/main/resources/site/parts/menu-list/menu-list.xml
@@ -1,0 +1,16 @@
+<part xmlns="urn:enonic:xp:model:1.0">
+    <display-name>menu-list (legacy, ikke bruk!)</display-name>
+    <form></form>
+    <config>
+        <allow-on-content-type>${app}:large-table</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article-chapter</allow-on-content-type>
+        <allow-on-content-type>${app}:melding</allow-on-content-type>
+        <allow-on-content-type>${app}:office-information</allow-on-content-type>
+        <allow-on-content-type>${app}:page-list</allow-on-content-type>
+        <allow-on-content-type>${app}:publishing-calendar</allow-on-content-type>
+        <allow-on-content-type>${app}:section-page</allow-on-content-type>
+        <allow-on-content-type>${app}:transport-page</allow-on-content-type>
+        <allow-on-content-type>portal:page-template</allow-on-content-type>
+    </config>
+</part>

--- a/src/main/resources/site/parts/notifications/notifications.ts
+++ b/src/main/resources/site/parts/notifications/notifications.ts
@@ -1,0 +1,3 @@
+import { componentPreviewController } from '../../../lib/controllers/component-preview-controller';
+
+export const get = componentPreviewController;

--- a/src/main/resources/site/parts/notifications/notifications.xml
+++ b/src/main/resources/site/parts/notifications/notifications.xml
@@ -1,0 +1,16 @@
+<part xmlns="urn:enonic:xp:model:1.0">
+    <display-name>notifications (legacy, ikke bruk!)</display-name>
+    <form></form>
+    <config>
+        <allow-on-content-type>${app}:large-table</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article-chapter</allow-on-content-type>
+        <allow-on-content-type>${app}:melding</allow-on-content-type>
+        <allow-on-content-type>${app}:office-information</allow-on-content-type>
+        <allow-on-content-type>${app}:page-list</allow-on-content-type>
+        <allow-on-content-type>${app}:publishing-calendar</allow-on-content-type>
+        <allow-on-content-type>${app}:section-page</allow-on-content-type>
+        <allow-on-content-type>${app}:transport-page</allow-on-content-type>
+        <allow-on-content-type>portal:page-template</allow-on-content-type>
+    </config>
+</part>

--- a/src/main/resources/site/parts/office-information/office-information.ts
+++ b/src/main/resources/site/parts/office-information/office-information.ts
@@ -1,0 +1,3 @@
+import { componentPreviewController } from '../../../lib/controllers/component-preview-controller';
+
+export const get = componentPreviewController;

--- a/src/main/resources/site/parts/office-information/office-information.xml
+++ b/src/main/resources/site/parts/office-information/office-information.xml
@@ -1,0 +1,16 @@
+<part xmlns="urn:enonic:xp:model:1.0">
+    <display-name>office-information (legacy, ikke bruk!)</display-name>
+    <form></form>
+    <config>
+        <allow-on-content-type>${app}:large-table</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article-chapter</allow-on-content-type>
+        <allow-on-content-type>${app}:melding</allow-on-content-type>
+        <allow-on-content-type>${app}:office-information</allow-on-content-type>
+        <allow-on-content-type>${app}:page-list</allow-on-content-type>
+        <allow-on-content-type>${app}:publishing-calendar</allow-on-content-type>
+        <allow-on-content-type>${app}:section-page</allow-on-content-type>
+        <allow-on-content-type>${app}:transport-page</allow-on-content-type>
+        <allow-on-content-type>portal:page-template</allow-on-content-type>
+    </config>
+</part>

--- a/src/main/resources/site/parts/page-crumbs/page-crumbs.ts
+++ b/src/main/resources/site/parts/page-crumbs/page-crumbs.ts
@@ -1,0 +1,3 @@
+import { componentPreviewController } from '../../../lib/controllers/component-preview-controller';
+
+export const get = componentPreviewController;

--- a/src/main/resources/site/parts/page-crumbs/page-crumbs.xml
+++ b/src/main/resources/site/parts/page-crumbs/page-crumbs.xml
@@ -1,0 +1,16 @@
+<part xmlns="urn:enonic:xp:model:1.0">
+    <display-name>page-crumbs (legacy, ikke bruk!)</display-name>
+    <form></form>
+    <config>
+        <allow-on-content-type>${app}:large-table</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article-chapter</allow-on-content-type>
+        <allow-on-content-type>${app}:melding</allow-on-content-type>
+        <allow-on-content-type>${app}:office-information</allow-on-content-type>
+        <allow-on-content-type>${app}:page-list</allow-on-content-type>
+        <allow-on-content-type>${app}:publishing-calendar</allow-on-content-type>
+        <allow-on-content-type>${app}:section-page</allow-on-content-type>
+        <allow-on-content-type>${app}:transport-page</allow-on-content-type>
+        <allow-on-content-type>portal:page-template</allow-on-content-type>
+    </config>
+</part>

--- a/src/main/resources/site/parts/page-heading/page-heading.ts
+++ b/src/main/resources/site/parts/page-heading/page-heading.ts
@@ -1,0 +1,3 @@
+import { componentPreviewController } from '../../../lib/controllers/component-preview-controller';
+
+export const get = componentPreviewController;

--- a/src/main/resources/site/parts/page-heading/page-heading.xml
+++ b/src/main/resources/site/parts/page-heading/page-heading.xml
@@ -1,0 +1,16 @@
+<part xmlns="urn:enonic:xp:model:1.0">
+    <display-name>page-heading (legacy, ikke bruk!)</display-name>
+    <form></form>
+    <config>
+        <allow-on-content-type>${app}:large-table</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article-chapter</allow-on-content-type>
+        <allow-on-content-type>${app}:melding</allow-on-content-type>
+        <allow-on-content-type>${app}:office-information</allow-on-content-type>
+        <allow-on-content-type>${app}:page-list</allow-on-content-type>
+        <allow-on-content-type>${app}:publishing-calendar</allow-on-content-type>
+        <allow-on-content-type>${app}:section-page</allow-on-content-type>
+        <allow-on-content-type>${app}:transport-page</allow-on-content-type>
+        <allow-on-content-type>portal:page-template</allow-on-content-type>
+    </config>
+</part>

--- a/src/main/resources/site/parts/page-list/page-list.ts
+++ b/src/main/resources/site/parts/page-list/page-list.ts
@@ -1,0 +1,3 @@
+import { componentPreviewController } from '../../../lib/controllers/component-preview-controller';
+
+export const get = componentPreviewController;

--- a/src/main/resources/site/parts/page-list/page-list.xml
+++ b/src/main/resources/site/parts/page-list/page-list.xml
@@ -1,0 +1,16 @@
+<part xmlns="urn:enonic:xp:model:1.0">
+    <display-name>page-list (legacy, ikke bruk!)</display-name>
+    <form></form>
+    <config>
+        <allow-on-content-type>${app}:large-table</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article-chapter</allow-on-content-type>
+        <allow-on-content-type>${app}:melding</allow-on-content-type>
+        <allow-on-content-type>${app}:office-information</allow-on-content-type>
+        <allow-on-content-type>${app}:page-list</allow-on-content-type>
+        <allow-on-content-type>${app}:publishing-calendar</allow-on-content-type>
+        <allow-on-content-type>${app}:section-page</allow-on-content-type>
+        <allow-on-content-type>${app}:transport-page</allow-on-content-type>
+        <allow-on-content-type>portal:page-template</allow-on-content-type>
+    </config>
+</part>

--- a/src/main/resources/site/parts/publishing-calendar/publishing-calendar.ts
+++ b/src/main/resources/site/parts/publishing-calendar/publishing-calendar.ts
@@ -1,0 +1,3 @@
+import { componentPreviewController } from '../../../lib/controllers/component-preview-controller';
+
+export const get = componentPreviewController;

--- a/src/main/resources/site/parts/publishing-calendar/publishing-calendar.xml
+++ b/src/main/resources/site/parts/publishing-calendar/publishing-calendar.xml
@@ -1,0 +1,16 @@
+<part xmlns="urn:enonic:xp:model:1.0">
+    <display-name>publishing-calendar (legacy, ikke bruk!)</display-name>
+    <form></form>
+    <config>
+        <allow-on-content-type>${app}:large-table</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article</allow-on-content-type>
+        <allow-on-content-type>${app}:main-article-chapter</allow-on-content-type>
+        <allow-on-content-type>${app}:melding</allow-on-content-type>
+        <allow-on-content-type>${app}:office-information</allow-on-content-type>
+        <allow-on-content-type>${app}:page-list</allow-on-content-type>
+        <allow-on-content-type>${app}:publishing-calendar</allow-on-content-type>
+        <allow-on-content-type>${app}:section-page</allow-on-content-type>
+        <allow-on-content-type>${app}:transport-page</allow-on-content-type>
+        <allow-on-content-type>portal:page-template</allow-on-content-type>
+    </config>
+</part>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Parts som benyttes i legacy templates ble slettet (ved en feiltagelse?) for lenge siden. I nyeste Content Studio vises det en del feilmeldinger dersom en komponent ikke faktisk har en schema-definisjon, tar derfor og gjeninnfører disse.