### PR TITLE
Gir redaktørene mulighet til å angi nosnippet

### DIFF
--- a/src/main/resources/lib/paths/custom-paths/custom-path.test.ts
+++ b/src/main/resources/lib/paths/custom-paths/custom-path.test.ts
@@ -29,6 +29,7 @@ const contentWithoutCustomPath: Content = {
         chatbotToggle: true,
         feedbackToggle: false,
         noindex: false,
+        nosnippet: false,
     },
     x: {
         'no-nav-navno': {

--- a/src/main/resources/site/content-types/area-page/area-page.ts
+++ b/src/main/resources/site/content-types/area-page/area-page.ts
@@ -145,7 +145,7 @@ export interface AreaPage {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets)
+   * Ikke vis utdrag (snippets) i Google-søk
    */
-  nosnippets: boolean;
+  nosnippet: boolean;
 }

--- a/src/main/resources/site/content-types/area-page/area-page.ts
+++ b/src/main/resources/site/content-types/area-page/area-page.ts
@@ -143,4 +143,9 @@ export interface AreaPage {
    * Skal ikke vises i søk
    */
   noindex: boolean;
+
+  /**
+   * Ikke vis utdrag (snippets)
+   */
+  nosnippets: boolean;
 }

--- a/src/main/resources/site/content-types/content-page-with-sidemenus/content-page-with-sidemenus.ts
+++ b/src/main/resources/site/content-types/content-page-with-sidemenus/content-page-with-sidemenus.ts
@@ -158,4 +158,9 @@ export interface ContentPageWithSidemenus {
    * Skal ikke vises i søk
    */
   noindex: boolean;
+
+  /**
+   * Ikke vis utdrag (snippets)
+   */
+  nosnippets: boolean;
 }

--- a/src/main/resources/site/content-types/content-page-with-sidemenus/content-page-with-sidemenus.ts
+++ b/src/main/resources/site/content-types/content-page-with-sidemenus/content-page-with-sidemenus.ts
@@ -160,7 +160,7 @@ export interface ContentPageWithSidemenus {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets)
+   * Ikke vis utdrag (snippets) i Google-søk
    */
-  nosnippets: boolean;
+  nosnippet: boolean;
 }

--- a/src/main/resources/site/content-types/current-topic-page/current-topic-page.ts
+++ b/src/main/resources/site/content-types/current-topic-page/current-topic-page.ts
@@ -118,4 +118,9 @@ export interface CurrentTopicPage {
    * Skal ikke vises i søk
    */
   noindex: boolean;
+
+  /**
+   * Ikke vis utdrag (snippets)
+   */
+  nosnippets: boolean;
 }

--- a/src/main/resources/site/content-types/current-topic-page/current-topic-page.ts
+++ b/src/main/resources/site/content-types/current-topic-page/current-topic-page.ts
@@ -120,7 +120,7 @@ export interface CurrentTopicPage {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets)
+   * Ikke vis utdrag (snippets) i Google-søk
    */
-  nosnippets: boolean;
+  nosnippet: boolean;
 }

--- a/src/main/resources/site/content-types/dynamic-page/dynamic-page.ts
+++ b/src/main/resources/site/content-types/dynamic-page/dynamic-page.ts
@@ -36,6 +36,11 @@ export interface DynamicPage {
   noindex: boolean;
 
   /**
+   * Ikke vis utdrag (snippets)
+   */
+  nosnippets: boolean;
+
+  /**
    * Skriv inn ønsket kort-url
    */
   customPath?: string;

--- a/src/main/resources/site/content-types/dynamic-page/dynamic-page.ts
+++ b/src/main/resources/site/content-types/dynamic-page/dynamic-page.ts
@@ -36,9 +36,9 @@ export interface DynamicPage {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets)
+   * Ikke vis utdrag (snippets) i Google-søk
    */
-  nosnippets: boolean;
+  nosnippet: boolean;
 
   /**
    * Skriv inn ønsket kort-url

--- a/src/main/resources/site/content-types/front-page-nested/front-page-nested.ts
+++ b/src/main/resources/site/content-types/front-page-nested/front-page-nested.ts
@@ -100,7 +100,7 @@ export interface FrontPageNested {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets)
+   * Ikke vis utdrag (snippets) i Google-søk
    */
-  nosnippets: boolean;
+  nosnippet: boolean;
 }

--- a/src/main/resources/site/content-types/front-page-nested/front-page-nested.ts
+++ b/src/main/resources/site/content-types/front-page-nested/front-page-nested.ts
@@ -98,4 +98,9 @@ export interface FrontPageNested {
    * Skal ikke vises i søk
    */
   noindex: boolean;
+
+  /**
+   * Ikke vis utdrag (snippets)
+   */
+  nosnippets: boolean;
 }

--- a/src/main/resources/site/content-types/front-page/front-page.ts
+++ b/src/main/resources/site/content-types/front-page/front-page.ts
@@ -110,7 +110,7 @@ export interface FrontPage {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets)
+   * Ikke vis utdrag (snippets) i Google-søk
    */
-  nosnippets: boolean;
+  nosnippet: boolean;
 }

--- a/src/main/resources/site/content-types/front-page/front-page.ts
+++ b/src/main/resources/site/content-types/front-page/front-page.ts
@@ -108,4 +108,9 @@ export interface FrontPage {
    * Skal ikke vises i søk
    */
   noindex: boolean;
+
+  /**
+   * Ikke vis utdrag (snippets)
+   */
+  nosnippets: boolean;
 }

--- a/src/main/resources/site/content-types/generic-page/generic-page.ts
+++ b/src/main/resources/site/content-types/generic-page/generic-page.ts
@@ -120,7 +120,7 @@ export interface GenericPage {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets)
+   * Ikke vis utdrag (snippets) i Google-søk
    */
-  nosnippets: boolean;
+  nosnippet: boolean;
 }

--- a/src/main/resources/site/content-types/generic-page/generic-page.ts
+++ b/src/main/resources/site/content-types/generic-page/generic-page.ts
@@ -118,4 +118,9 @@ export interface GenericPage {
    * Skal ikke vises i søk
    */
   noindex: boolean;
+
+  /**
+   * Ikke vis utdrag (snippets)
+   */
+  nosnippets: boolean;
 }

--- a/src/main/resources/site/content-types/guide-page/guide-page.ts
+++ b/src/main/resources/site/content-types/guide-page/guide-page.ts
@@ -160,7 +160,7 @@ export interface GuidePage {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets)
+   * Ikke vis utdrag (snippets) i Google-søk
    */
-  nosnippets: boolean;
+  nosnippet: boolean;
 }

--- a/src/main/resources/site/content-types/guide-page/guide-page.ts
+++ b/src/main/resources/site/content-types/guide-page/guide-page.ts
@@ -158,4 +158,9 @@ export interface GuidePage {
    * Skal ikke vises i søk
    */
   noindex: boolean;
+
+  /**
+   * Ikke vis utdrag (snippets)
+   */
+  nosnippets: boolean;
 }

--- a/src/main/resources/site/content-types/main-article/main-article.ts
+++ b/src/main/resources/site/content-types/main-article/main-article.ts
@@ -216,9 +216,9 @@ export interface MainArticle {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets)
+   * Ikke vis utdrag (snippets) i Google-søk
    */
-  nosnippets: boolean;
+  nosnippet: boolean;
 
   /**
    * Nøkkelord (internt søk)

--- a/src/main/resources/site/content-types/main-article/main-article.ts
+++ b/src/main/resources/site/content-types/main-article/main-article.ts
@@ -216,6 +216,11 @@ export interface MainArticle {
   noindex: boolean;
 
   /**
+   * Ikke vis utdrag (snippets)
+   */
+  nosnippets: boolean;
+
+  /**
    * Nøkkelord (internt søk)
    */
   keywords?: Array<string>;

--- a/src/main/resources/site/content-types/office-editorial-page/office-editorial-page.ts
+++ b/src/main/resources/site/content-types/office-editorial-page/office-editorial-page.ts
@@ -34,4 +34,9 @@ export interface OfficeEditorialPage {
    * Skal ikke vises i søk
    */
   noindex: boolean;
+
+  /**
+   * Ikke vis utdrag (snippets)
+   */
+  nosnippets: boolean;
 }

--- a/src/main/resources/site/content-types/office-editorial-page/office-editorial-page.ts
+++ b/src/main/resources/site/content-types/office-editorial-page/office-editorial-page.ts
@@ -36,7 +36,7 @@ export interface OfficeEditorialPage {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets)
+   * Ikke vis utdrag (snippets) i Google-søk
    */
-  nosnippets: boolean;
+  nosnippet: boolean;
 }

--- a/src/main/resources/site/content-types/overview/overview.ts
+++ b/src/main/resources/site/content-types/overview/overview.ts
@@ -86,9 +86,9 @@ export interface Overview {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets)
+   * Ikke vis utdrag (snippets) i Google-søk
    */
-  nosnippets: boolean;
+  nosnippet: boolean;
 
   /**
    * -

--- a/src/main/resources/site/content-types/overview/overview.ts
+++ b/src/main/resources/site/content-types/overview/overview.ts
@@ -86,6 +86,11 @@ export interface Overview {
   noindex: boolean;
 
   /**
+   * Ikke vis utdrag (snippets)
+   */
+  nosnippets: boolean;
+
+  /**
    * -
    */
   allProducts?: undefined;

--- a/src/main/resources/site/content-types/page-list/page-list.ts
+++ b/src/main/resources/site/content-types/page-list/page-list.ts
@@ -86,9 +86,9 @@ export interface PageList {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets)
+   * Ikke vis utdrag (snippets) i Google-søk
    */
-  nosnippets: boolean;
+  nosnippet: boolean;
 
   /**
    * Nøkkelord (internt søk)

--- a/src/main/resources/site/content-types/page-list/page-list.ts
+++ b/src/main/resources/site/content-types/page-list/page-list.ts
@@ -86,6 +86,11 @@ export interface PageList {
   noindex: boolean;
 
   /**
+   * Ikke vis utdrag (snippets)
+   */
+  nosnippets: boolean;
+
+  /**
    * Nøkkelord (internt søk)
    */
   keywords?: Array<string>;

--- a/src/main/resources/site/content-types/publishing-calendar/publishing-calendar.ts
+++ b/src/main/resources/site/content-types/publishing-calendar/publishing-calendar.ts
@@ -21,9 +21,9 @@ export interface PublishingCalendar {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets)
+   * Ikke vis utdrag (snippets) i Google-søk
    */
-  nosnippets: boolean;
+  nosnippet: boolean;
 
   /**
    * Nøkkelord (internt søk)

--- a/src/main/resources/site/content-types/publishing-calendar/publishing-calendar.ts
+++ b/src/main/resources/site/content-types/publishing-calendar/publishing-calendar.ts
@@ -21,6 +21,11 @@ export interface PublishingCalendar {
   noindex: boolean;
 
   /**
+   * Ikke vis utdrag (snippets)
+   */
+  nosnippets: boolean;
+
+  /**
    * Nøkkelord (internt søk)
    */
   keywords?: Array<string>;

--- a/src/main/resources/site/content-types/section-page/section-page.ts
+++ b/src/main/resources/site/content-types/section-page/section-page.ts
@@ -116,6 +116,11 @@ export interface SectionPage {
   noindex: boolean;
 
   /**
+   * Ikke vis utdrag (snippets)
+   */
+  nosnippets: boolean;
+
+  /**
    * Nøkkelord (internt søk)
    */
   keywords?: Array<string>;

--- a/src/main/resources/site/content-types/section-page/section-page.ts
+++ b/src/main/resources/site/content-types/section-page/section-page.ts
@@ -116,9 +116,9 @@ export interface SectionPage {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets)
+   * Ikke vis utdrag (snippets) i Google-søk
    */
-  nosnippets: boolean;
+  nosnippet: boolean;
 
   /**
    * Nøkkelord (internt søk)

--- a/src/main/resources/site/content-types/situation-page/situation-page.ts
+++ b/src/main/resources/site/content-types/situation-page/situation-page.ts
@@ -135,7 +135,7 @@ export interface SituationPage {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets)
+   * Ikke vis utdrag (snippets) i Google-søk
    */
-  nosnippets: boolean;
+  nosnippet: boolean;
 }

--- a/src/main/resources/site/content-types/situation-page/situation-page.ts
+++ b/src/main/resources/site/content-types/situation-page/situation-page.ts
@@ -133,4 +133,9 @@ export interface SituationPage {
    * Skal ikke vises i søk
    */
   noindex: boolean;
+
+  /**
+   * Ikke vis utdrag (snippets)
+   */
+  nosnippets: boolean;
 }

--- a/src/main/resources/site/content-types/themed-article-page/themed-article-page.ts
+++ b/src/main/resources/site/content-types/themed-article-page/themed-article-page.ts
@@ -160,7 +160,7 @@ export interface ThemedArticlePage {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets)
+   * Ikke vis utdrag (snippets) i Google-søk
    */
-  nosnippets: boolean;
+  nosnippet: boolean;
 }

--- a/src/main/resources/site/content-types/themed-article-page/themed-article-page.ts
+++ b/src/main/resources/site/content-types/themed-article-page/themed-article-page.ts
@@ -158,4 +158,9 @@ export interface ThemedArticlePage {
    * Skal ikke vises i søk
    */
   noindex: boolean;
+
+  /**
+   * Ikke vis utdrag (snippets)
+   */
+  nosnippets: boolean;
 }

--- a/src/main/resources/site/content-types/transport-page/transport-page.ts
+++ b/src/main/resources/site/content-types/transport-page/transport-page.ts
@@ -66,6 +66,11 @@ export interface TransportPage {
   noindex: boolean;
 
   /**
+   * Ikke vis utdrag (snippets)
+   */
+  nosnippets: boolean;
+
+  /**
    * Nøkkelord (internt søk)
    */
   keywords?: Array<string>;

--- a/src/main/resources/site/content-types/transport-page/transport-page.ts
+++ b/src/main/resources/site/content-types/transport-page/transport-page.ts
@@ -66,9 +66,9 @@ export interface TransportPage {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets)
+   * Ikke vis utdrag (snippets) i Google-søk
    */
-  nosnippets: boolean;
+  nosnippet: boolean;
 
   /**
    * Nøkkelord (internt søk)

--- a/src/main/resources/site/mixins/dynamic-page-common/dynamic-page-common.ts
+++ b/src/main/resources/site/mixins/dynamic-page-common/dynamic-page-common.ts
@@ -41,7 +41,7 @@ export interface DynamicPageCommon {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets)
+   * Ikke vis utdrag (snippets) i Google-søk
    */
-  nosnippets: boolean;
+  nosnippet: boolean;
 }

--- a/src/main/resources/site/mixins/dynamic-page-common/dynamic-page-common.ts
+++ b/src/main/resources/site/mixins/dynamic-page-common/dynamic-page-common.ts
@@ -39,4 +39,9 @@ export interface DynamicPageCommon {
    * Skal ikke vises i søk
    */
   noindex: boolean;
+
+  /**
+   * Ikke vis utdrag (snippets)
+   */
+  nosnippets: boolean;
 }

--- a/src/main/resources/site/mixins/seo/seo.ts
+++ b/src/main/resources/site/mixins/seo/seo.ts
@@ -14,4 +14,9 @@ export interface Seo {
    * Skal ikke vises i søk
    */
   noindex: boolean;
+
+  /**
+   * Ikke vis utdrag (snippets) i Google-søk
+   */
+  nosnippet: boolean;
 }

--- a/src/main/resources/site/mixins/seo/seo.xml
+++ b/src/main/resources/site/mixins/seo/seo.xml
@@ -30,6 +30,14 @@
                         Gjelder både søket på nav.no og eksternt søk som Google og Bing
                     </help-text>
                 </input>
+                <input name="nosnippet" type="CheckBox">
+                    <label>
+                        Ikke vis utdrag (snippets) i Google-søk
+                    </label>
+                    <help-text>
+                        Google vil ikke forsøke å vise utdrag fra denne siden i søkeresultatet. Innholdet vil fortsatt være søkbart.
+                    </help-text>
+                </input>
             </items>
         </field-set>
     </form>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Enkelte ganger ønsker vi at Google ikke forsøker å hente ut snippets fra et innhold basert på hva brukeren har søkt etter. Feks kan det gi feilaktige svar til brukeren dersom teksten vises ute av kontekst i Google-søk.

Denne funksjonen lar redaktøren sette nosnippet for hele innholdet.

## Testing
Testet i q6

