### PR TITLE
Optimaliserer redirects-søk ved not found + bedre sitecontent params validering

### DIFF
--- a/src/main/resources/lib/paths/path-utils.ts
+++ b/src/main/resources/lib/paths/path-utils.ts
@@ -19,3 +19,5 @@ export const hasExternalProductUrl = (
     !!(content as ContentWithExternalProductUrl).data?.externalProductUrl;
 
 export const stripRedirectsPathPrefix = (path: string) => path.replace(redirectsPathFilter, '');
+
+export const stripLeadingAndTrailingSlash = (path: string) => path.replace(/(^\/)|(\/$)/, '');

--- a/src/main/resources/lib/paths/path-utils.ts
+++ b/src/main/resources/lib/paths/path-utils.ts
@@ -1,5 +1,7 @@
 import { NAVNO_ROOT_PATH, REDIRECTS_PATH } from '../constants';
 import { Content, CONTENT_ROOT_PATH } from '/lib/xp/content';
+import { contentLibGetStandard } from '../time-travel/standard-functions';
+import { logger } from '../utils/logging';
 
 type ContentWithExternalProductUrl = Content & { data: { externalProductUrl: string } };
 
@@ -21,3 +23,14 @@ export const hasExternalProductUrl = (
 export const stripRedirectsPathPrefix = (path: string) => path.replace(redirectsPathFilter, '');
 
 export const stripLeadingAndTrailingSlash = (path: string) => path.replace(/(^\/)|(\/$)/, '');
+
+export const isWellFormedContentRef = (contentRef: string) => {
+    try {
+        // This will throw if the key is malformed (invalid characters etc)
+        contentLibGetStandard({ key: contentRef });
+        return true;
+    } catch (e) {
+        logger.info(`Content ref validation error for "${contentRef}" - ${e}`);
+        return false;
+    }
+};

--- a/src/main/resources/lib/utils/version-utils.ts
+++ b/src/main/resources/lib/utils/version-utils.ts
@@ -7,7 +7,6 @@ import { getUnixTimeFromDateTimeString } from './datetime-utils';
 import { contentTypesWithCustomEditor } from '../contenttype-lists';
 import { getLayersData } from '../localization/layers-data';
 import { getLayersMigrationArchivedContentRef } from '../time-travel/layers-migration-refs';
-import { getLayerMigrationData } from '../localization/layers-migration/migration-data';
 
 const MAX_VERSIONS_COUNT_TO_RETRIEVE = 2000;
 

--- a/src/main/resources/services/service-utils.ts
+++ b/src/main/resources/services/service-utils.ts
@@ -1,14 +1,11 @@
 import { customSelectorEditIcon } from './custom-selector-icons';
 import { buildEditorPathFromContext } from '../lib/paths/editor-path';
-import { logger } from '../lib/utils/logging';
+import { stripLeadingAndTrailingSlash } from '../lib/paths/path-utils';
 
 const getServiceName = (req: XP.Request) => req.contextPath.split('/').slice(-1)[0];
 
 export const getServiceRequestSubPath = (req: XP.Request) =>
-    req.path
-        .split(getServiceName(req))
-        .slice(-1)[0]
-        .replace(/(^\/)|(\/$)/, ''); // Trim leading/trailing slash
+    stripLeadingAndTrailingSlash(req.path.split(getServiceName(req)).slice(-1)[0]);
 
 // We can't use target or onclick to make the link open in a new tab, as content studio removes
 // these attributes when parsing the dom elements from the customselector icon. We set a classname

--- a/src/main/resources/services/sitecontent/public/not-found-redirects.ts
+++ b/src/main/resources/services/sitecontent/public/not-found-redirects.ts
@@ -1,5 +1,5 @@
 import * as contentLib from '/lib/xp/content';
-import { Content } from '/lib/xp/content';
+import { Content, CONTENT_ROOT_PATH } from '/lib/xp/content';
 import { RepoBranch } from '../../../types/common';
 import { runInContext } from '../../../lib/context/run-in-context';
 import { stripLeadingAndTrailingSlash, stripPathPrefix } from '../../../lib/paths/path-utils';
@@ -54,7 +54,7 @@ const getRedirectFromLegacyPath = (path: string) => {
     });
 };
 
-// Finds the nearest parent with the internal link content type + redirectSubpaths flag
+// Finds the nearest ancestor with the internal link content type + redirectSubpaths flag
 // Use this as a redirect if found
 const getParentRedirectContent = (path: string): null | Content => {
     if (!path) {
@@ -71,7 +71,8 @@ const getParentRedirectContent = (path: string): null | Content => {
     }
 
     const ancestorNodePaths = parentPathSegments.map(
-        (_, index, ancestorPath) => `/content/${ancestorPath.slice(0, index + 1).join('/')}`
+        (_, index, ancestorPath) =>
+            `${CONTENT_ROOT_PATH}/${ancestorPath.slice(0, index + 1).join('/')}`
     );
 
     const parentContent = contentLib.query({

--- a/src/main/resources/services/sitecontent/public/not-found-redirects.ts
+++ b/src/main/resources/services/sitecontent/public/not-found-redirects.ts
@@ -56,7 +56,7 @@ const getRedirectFromLegacyPath = (path: string) => {
 
 // Finds the nearest ancestor with the internal link content type + redirectSubpaths flag
 // Use this as a redirect if found
-const getParentRedirectContent = (path: string): null | Content => {
+const getRedirectFromAncestors = (path: string): null | Content => {
     if (!path) {
         return null;
     }
@@ -75,7 +75,7 @@ const getParentRedirectContent = (path: string): null | Content => {
             `${CONTENT_ROOT_PATH}/${ancestorPath.slice(0, index + 1).join('/')}`
     );
 
-    const parentContent = contentLib.query({
+    const redirectContent = contentLib.query({
         count: 1,
         sort: '_path DESC',
         filters: {
@@ -104,10 +104,10 @@ const getParentRedirectContent = (path: string): null | Content => {
         },
     }).hits[0];
 
-    return parentContent || null;
+    return redirectContent || null;
 };
 
-const getContentFromRedirectsFolder = (path: string) =>
+const getFromRedirectsFolder = (path: string) =>
     contentLib.get({ key: `${REDIRECTS_ROOT_PATH}${path}` });
 
 export const sitecontentNotFoundRedirect = ({
@@ -131,9 +131,9 @@ export const sitecontentNotFoundRedirect = ({
         // 2. A parent match in the regular content structure
         // 3. A parent match in the redirects folder
         const redirectContent =
-            getContentFromRedirectsFolder(strippedPath) ||
-            getParentRedirectContent(pathRequested) ||
-            getParentRedirectContent(`${REDIRECTS_ROOT_PATH}${strippedPath}`);
+            getFromRedirectsFolder(strippedPath) ||
+            getRedirectFromAncestors(pathRequested) ||
+            getRedirectFromAncestors(`${REDIRECTS_ROOT_PATH}${strippedPath}`);
 
         return redirectContent
             ? runInLocaleContext({ locale: redirectContent.language }, () =>

--- a/src/main/resources/services/sitecontent/public/not-found-redirects.ts
+++ b/src/main/resources/services/sitecontent/public/not-found-redirects.ts
@@ -2,12 +2,14 @@ import * as contentLib from '/lib/xp/content';
 import { Content } from '/lib/xp/content';
 import { RepoBranch } from '../../../types/common';
 import { runInContext } from '../../../lib/context/run-in-context';
-import { getParentPath, stripPathPrefix } from '../../../lib/paths/path-utils';
+import { stripLeadingAndTrailingSlash, stripPathPrefix } from '../../../lib/paths/path-utils';
 import { REDIRECTS_ROOT_PATH } from '../../../lib/constants';
 import { runInLocaleContext } from '../../../lib/localization/locale-context';
 import { runSitecontentGuillotineQuery } from '../../../lib/guillotine/queries/run-sitecontent-query';
 import { transformToRedirect } from '../common/transform-to-redirect';
 import { SitecontentResponse } from '../common/content-response';
+
+const MAX_PARENT_PATH_LENGTH = 10;
 
 // The old Enonic CMS had urls suffixed with <contentKey>.cms
 // This contentKey was saved as an x-data field after the migration to XP
@@ -52,31 +54,56 @@ const getRedirectFromLegacyPath = (path: string) => {
     });
 };
 
-// Find the nearest parent for a not-found content. If it is an internal link with the
-// redirectSubpaths flag, use this as a redirect
+// Finds the nearest parent with the internal link content type + redirectSubpaths flag
+// Use this as a redirect if found
 const getParentRedirectContent = (path: string): null | Content => {
     if (!path) {
         return null;
     }
 
-    const parentPath = getParentPath(path);
-    if (!parentPath) {
+    const parentPathSegments = stripLeadingAndTrailingSlash(path)
+        .split('/')
+        .slice(0, -1)
+        .slice(0, MAX_PARENT_PATH_LENGTH);
+
+    if (parentPathSegments.length === 0) {
         return null;
     }
 
-    const parentContent = contentLib.get({ key: parentPath });
-    if (!parentContent) {
-        return getParentRedirectContent(parentPath);
-    }
+    const ancestorNodePaths = parentPathSegments.map(
+        (_, index, ancestorPath) => `/content/${ancestorPath.slice(0, index + 1).join('/')}`
+    );
 
-    if (
-        parentContent.type === 'no.nav.navno:internal-link' &&
-        parentContent.data.redirectSubpaths
-    ) {
-        return parentContent;
-    }
+    const parentContent = contentLib.query({
+        count: 1,
+        sort: '_path DESC',
+        filters: {
+            boolean: {
+                must: [
+                    {
+                        hasValue: {
+                            field: 'data.redirectSubpaths',
+                            values: ['true'],
+                        },
+                    },
+                    {
+                        hasValue: {
+                            field: 'type',
+                            values: ['no.nav.navno:internal-link'],
+                        },
+                    },
+                    {
+                        hasValue: {
+                            field: '_path',
+                            values: ancestorNodePaths,
+                        },
+                    },
+                ],
+            },
+        },
+    }).hits[0];
 
-    return null;
+    return parentContent || null;
 };
 
 const getContentFromRedirectsFolder = (path: string) =>

--- a/src/main/resources/services/sitecontent/sitecontent.ts
+++ b/src/main/resources/services/sitecontent/sitecontent.ts
@@ -6,6 +6,7 @@ import { RepoBranch } from '../../types/common';
 import { SITECONTENT_404_MSG_PREFIX } from '../../lib/constants';
 import { sitecontentDraftResponse } from './draft/draft-response';
 import { SitecontentResponse } from './common/content-response';
+import { isWellFormedContentRef } from '../../lib/paths/path-utils';
 
 type SiteContentParams = {
     id: string;
@@ -64,6 +65,17 @@ export const get = (req: XP.Request) => {
             status: 400,
             body: {
                 message: 'Invalid branch specified',
+            },
+            contentType: 'application/json',
+        };
+    }
+
+    if (!isWellFormedContentRef(idOrPath)) {
+        logger.warning(`Id or path failed to validate: ${idOrPath}`);
+        return {
+            status: 400,
+            body: {
+                message: 'Content id validation error',
             },
             contentType: 'application/json',
         };


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Validerer at id-parameteret til sitecontent-service'en er formet som en gyldig content referanse
- Setter en maks-grense for lengde på parent path-segmenter som inkluderes ved søk etter ancestor redirects
- Optimaliserer søk etter ancestor redirects: Kjører nå ett enkelt query for potensielle redirects, fremfor rekursiv sjekk på alle ancestors.