### PR TITLE
Fikser selector for excluded content for oversiktssider

### DIFF
--- a/src/main/resources/lib/utils/datetime-utils.ts
+++ b/src/main/resources/lib/utils/datetime-utils.ts
@@ -22,7 +22,3 @@ export const fixDateFormat = (date: string) => {
 
 export const dateTimesAreEqual = (dateTime1: string, dateTime2: string) =>
     new Date(fixDateFormat(dateTime1)).getTime() === new Date(fixDateFormat(dateTime2)).getTime();
-
-const xpDateTimePattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.?\d*Z?$/;
-
-export const isXpDateTime = (value: string) => xpDateTimePattern.test(value);

--- a/src/main/resources/lib/utils/string-utils.ts
+++ b/src/main/resources/lib/utils/string-utils.ts
@@ -1,0 +1,1 @@
+export const stripLineBreaks = (str: string) => str.replace(/\r?\n|\r/g, '');

--- a/src/main/resources/services/contentSelector/contentSelector.ts
+++ b/src/main/resources/services/contentSelector/contentSelector.ts
@@ -8,6 +8,7 @@ import { ContentDescriptor } from '../../types/content-types/content-config';
 import { stripPathPrefix } from '../../lib/paths/path-utils';
 import { parseJsonToArray, removeDuplicates } from '../../lib/utils/array-utils';
 import { getNestedValues } from '../../lib/utils/object-utils';
+import { stripLineBreaks } from '../../lib/utils/string-utils';
 
 type SelectorHit = XP.CustomSelectorServiceResponseHit;
 
@@ -16,16 +17,17 @@ type ReqParams = {
     selectorQuery?: string;
 } & XP.CustomSelectorServiceRequestParams;
 
-const formatString = (str: string, withQuotes: boolean) => (withQuotes ? `"${str}"` : str);
+const CONTENT_FIELD_REF_PATTERN = /{(\w|\.|-|,|_| )+}/g;
 
-const stripLineBreaks = (str: string) => str.replace(/\r?\n|\r/g, '');
+const formatFieldValue = (value: string, withQuotes: boolean) =>
+    withQuotes ? `"${value}"` : value;
 
 const parseContentTypes = (contentTypesJson?: string) => {
     if (!contentTypesJson) {
         return null;
     }
 
-    return parseJsonToArray<ContentDescriptor>(stripLineBreaks(contentTypesJson));
+    return parseJsonToArray<ContentDescriptor>(stripLineBreaks(contentTypesJson.trim()));
 };
 
 const injectValuesFromContent = (str: string) => {
@@ -35,18 +37,18 @@ const injectValuesFromContent = (str: string) => {
         return str;
     }
 
-    return str.replace(/{(\w|\.|-|,)+}/g, (match) => {
+    return str.replace(CONTENT_FIELD_REF_PATTERN, (match) => {
         const [fieldKey, withQuotes] = match.replace(/[{}]/g, '').split(',');
 
         const isWithQuotes = withQuotes?.trim() === 'true';
 
         const fieldValue = getNestedValues(content, fieldKey);
         if (typeof fieldValue === 'string') {
-            return formatString(fieldValue, isWithQuotes);
+            return formatFieldValue(fieldValue, isWithQuotes);
         }
 
         if (Array.isArray(fieldValue)) {
-            return fieldValue.map((value) => formatString(value, isWithQuotes)).join(',');
+            return fieldValue.map((value) => formatFieldValue(value, isWithQuotes)).join(',');
         }
 
         return JSON.stringify(fieldValue);
@@ -129,8 +131,6 @@ export const get = (req: XP.Request) => {
 
     const query = buildQuery(userQuery, selectorQuery);
     const contentTypes = parseContentTypes(contentTypesJson);
-
-    logger.info(query);
 
     const hitsFromIds = getHitsFromIds(customSelectorParseSelectedIdsFromReq(req));
     const hitsFromQuery = getHitsFromQuery(query, contentTypes || undefined, sort);

--- a/src/main/resources/site/content-types/content-data-locale-fallback/content-data-locale-fallback.xml
+++ b/src/main/resources/site/content-types/content-data-locale-fallback/content-data-locale-fallback.xml
@@ -43,8 +43,7 @@
                     <occurrences minimum="1" maximum="1"/>
                     <config>
                         <service>contentSelector</service>
-                        <param value="contentTypes">{data.contentTypes}</param>
-                        <param value="selectorQuery">{data.contentQuery}</param>
+                        <param value="selectorQuery">{data.contentQuery} AND type IN ({data.contentTypes, true})</param>
                         <param value="sort">displayName ASC</param>
                     </config>
                 </input>

--- a/src/main/resources/site/content-types/forms-overview/forms-overview.xml
+++ b/src/main/resources/site/content-types/forms-overview/forms-overview.xml
@@ -124,9 +124,12 @@
                     <occurrences minimum="0" maximum="0"/>
                     <config>
                         <service>contentSelector</service>
-                        <!-- Don't add linebreaks/whitespace to the param body values, as these will be included in the service calls -_- -->
-                        <param value="contentTypes">["no.nav.navno:content-page-with-sidemenus","no.nav.navno:guide-page"]</param>
-                        <param value="selectorQuery">data.audience._selected="{data.audience._selected}" AND data.formDetailsTargets LIKE "*"</param>
+                        <param value="contentTypes">
+                            ["no.nav.navno:content-page-with-sidemenus","no.nav.navno:guide-page"]
+                        </param>
+                        <param value="selectorQuery">data.audience._selected="{data.audience._selected}" AND
+                            data.formDetailsTargets LIKE "*"
+                        </param>
                         <param value="sort">data.area ASC, displayName ASC</param>
                     </config>
                 </input>

--- a/src/main/resources/site/content-types/overview/overview.xml
+++ b/src/main/resources/site/content-types/overview/overview.xml
@@ -54,9 +54,10 @@
                     <occurrences minimum="0" maximum="0"/>
                     <config>
                         <service>contentSelector</service>
-                        <!-- Don't add linebreaks/whitespace to the param body values, as these will be included in the service calls -_- -->
-                        <param value="contentTypes">["no.nav.navno:content-page-with-sidemenus","no.nav.navno:guide-page","no.nav.navno:themed-article-page"]</param>
-                        <param value="selectorQuery">data.audience._selected="{data.audience._selected}"</param>
+                        <param value="contentTypes">
+                            ["no.nav.navno:content-page-with-sidemenus","no.nav.navno:guide-page","no.nav.navno:themed-article-page"]
+                        </param>
+                        <param value="selectorQuery">data.audience._selected IN ({data.audience,true})</param>
                         <param value="sort">data.area ASC, displayName ASC</param>
                     </config>
                 </input>


### PR DESCRIPTION
- Fikser selector for excluded content slik at den setter audience på korrekt måte i queryet
- Fikser contentSelector service slik at den håndterer linebreaks i input-parametre
- Legger til støtte for injecting av arrays i contentSelector
- Fjerner noe ubrukt kode
