### PR TITLE
Skriver om resolving av request paths til frontend for å prioritere kort-url'er og locale-url'er

### DIFF
--- a/src/main/resources/lib/localization/locale-utils.ts
+++ b/src/main/resources/lib/localization/locale-utils.ts
@@ -1,23 +1,5 @@
 import { Content } from '/lib/xp/content';
-import { getLayersData } from './layers-data';
 import { forceArray } from '../utils/array-utils';
-
-export const buildLocalePath = (basePath: string, locale: string) => {
-    const { defaultLocale, localeToRepoIdMap } = getLayersData();
-
-    if (locale === defaultLocale || !localeToRepoIdMap[locale]) {
-        return basePath;
-    }
-
-    const localeSuffix = `/${locale}`;
-
-    if (basePath.endsWith(localeSuffix)) {
-        return basePath;
-    }
-
-    // Removes trailing slash from base path
-    return basePath.replace(/(\/)?$/, localeSuffix);
-};
 
 export const isContentLocalized = (content: Content) =>
     !forceArray(content.inherit).includes('CONTENT');

--- a/src/main/resources/lib/paths/locale-paths.ts
+++ b/src/main/resources/lib/paths/locale-paths.ts
@@ -1,0 +1,41 @@
+import { getLayersData, isValidLocale } from '../localization/layers-data';
+
+type PathAndLocale = {
+    basePath: string;
+    locale: string;
+};
+
+export const resolveLocalePathToBasePath = (localePath: string): PathAndLocale | null => {
+    const { defaultLocale } = getLayersData();
+
+    const pathSegments = localePath.split('/');
+    const possibleLocale = pathSegments.pop();
+
+    // The default locale should not be an allowed suffix. For this locale we only want to resolve
+    // requests for the actual path, with no locale-suffix.
+    if (possibleLocale === defaultLocale || !isValidLocale(possibleLocale)) {
+        return null;
+    }
+
+    return {
+        locale: possibleLocale,
+        basePath: pathSegments.join('/'),
+    };
+};
+
+export const buildLocalePath = (basePath: string, locale: string) => {
+    const { defaultLocale, localeToRepoIdMap } = getLayersData();
+
+    if (locale === defaultLocale || !localeToRepoIdMap[locale]) {
+        return basePath;
+    }
+
+    const localeSuffix = `/${locale}`;
+
+    if (basePath.endsWith(localeSuffix)) {
+        return basePath;
+    }
+
+    // Removes trailing slash from base path
+    return basePath.replace(/(\/)?$/, localeSuffix);
+};

--- a/src/main/resources/lib/paths/public-path.ts
+++ b/src/main/resources/lib/paths/public-path.ts
@@ -1,7 +1,8 @@
 import { Content } from '/lib/xp/content';
 import { hasValidCustomPath } from './custom-paths/custom-path-utils';
 import { stripPathPrefix } from './path-utils';
-import { buildLocalePath, isContentLocalized } from '../localization/locale-utils';
+import { isContentLocalized } from '../localization/locale-utils';
+import { buildLocalePath } from './locale-paths';
 
 export const getPublicPath = (content: Content, locale: string): string => {
     const basePath = hasValidCustomPath(content)

--- a/src/main/resources/services/customPathSelector/customPathSelector.ts
+++ b/src/main/resources/services/customPathSelector/customPathSelector.ts
@@ -92,7 +92,7 @@ const getResult = ({
     const contentWithInternalPath = runInContext({ branch: 'master' }, () =>
         contentLib.get({ key: `${NAVNO_ROOT_PATH}${suggestedPath}` })
     );
-    if (contentWithInternalPath && contentWithInternalPath.type !== 'portal:site') {
+    if (contentWithInternalPath) {
         return {
             id: suggestedPath,
             displayName: suggestedPath,

--- a/src/main/resources/services/customPathSelector/customPathSelector.ts
+++ b/src/main/resources/services/customPathSelector/customPathSelector.ts
@@ -93,10 +93,12 @@ const getResult = ({
         contentLib.get({ key: `${NAVNO_ROOT_PATH}${suggestedPath}` })
     );
     if (contentWithInternalPath && contentWithInternalPath.type !== 'portal:site') {
-        return generateErrorHit(
-            `Feil: "${suggestedPath}" er allerede i bruk som vanlig url`,
-            `"${contentWithInternalPath.displayName}" har denne url'en`
-        );
+        return {
+            id: suggestedPath,
+            displayName: suggestedPath,
+            description: `Advarsel: ${suggestedPath} er allerede i bruk som vanlig url for "${contentWithInternalPath.displayName}" - denne vil overstyres av kort-url`,
+            icon: customSelectorWarningIcon,
+        };
     }
 
     const ingressIsOurs = verifyIngressOwner(suggestedPath);

--- a/src/main/resources/services/sitecontent/common/find-target-content-and-locale.ts
+++ b/src/main/resources/services/sitecontent/common/find-target-content-and-locale.ts
@@ -29,7 +29,7 @@ const getPathQueryParams = (path: string) => ({
                 {
                     hasValue: {
                         field: 'data.customPath',
-                        values: [stripPathPrefix(path)],
+                        values: [stripPathPrefix(path) || '/'],
                     },
                 },
             ],

--- a/src/main/resources/services/sitecontent/common/find-target-content-and-locale.ts
+++ b/src/main/resources/services/sitecontent/common/find-target-content-and-locale.ts
@@ -29,6 +29,7 @@ const getPathQueryParams = (path: string) => ({
                 {
                     hasValue: {
                         field: 'data.customPath',
+                        // Handle root path with a fallback to '/'
                         values: [stripPathPrefix(path) || '/'],
                     },
                 },

--- a/src/main/resources/services/sitecontent/public/special-redirects.ts
+++ b/src/main/resources/services/sitecontent/public/special-redirects.ts
@@ -3,7 +3,8 @@ import { Content } from '/lib/xp/content';
 import { RepoBranch } from '../../../types/common';
 import { hasValidCustomPath } from '../../../lib/paths/custom-paths/custom-path-utils';
 import { getPublicPath } from '../../../lib/paths/public-path';
-import { buildLocalePath, isContentLocalized } from '../../../lib/localization/locale-utils';
+import { isContentLocalized } from '../../../lib/localization/locale-utils';
+import { buildLocalePath } from '../../../lib/paths/locale-paths';
 import { runInLocaleContext } from '../../../lib/localization/locale-context';
 import { logger } from '../../../lib/utils/logging';
 import {

--- a/src/main/resources/services/sitecontentPaths/sitecontentPaths.ts
+++ b/src/main/resources/services/sitecontentPaths/sitecontentPaths.ts
@@ -12,7 +12,7 @@ import { validateServiceSecretHeader } from '../../lib/utils/auth-utils';
 import { stripPathPrefix, stripRedirectsPathPrefix } from '../../lib/paths/path-utils';
 import { getPublicPath } from '../../lib/paths/public-path';
 import { removeDuplicates } from '../../lib/utils/array-utils';
-import { buildLocalePath } from '../../lib/localization/locale-utils';
+import { buildLocalePath } from '../../lib/paths/locale-paths';
 import { hasValidCustomPath } from '../../lib/paths/custom-paths/custom-path-utils';
 import { queryAllLayersToRepoIdBuckets } from '../../lib/localization/layers-repo-utils/query-all-layers';
 


### PR DESCRIPTION
Den spesifikke case'en som gjør at denne endringen er nødvendig nå, er ny engelsk forside som vi vil ha på `nav.no/en`. `/en` brukes også som en mappe for alt av "legacy" engelsk-innhold som ikke ligger i layers, derfor må vi ha mulighet for at kort-url'er/locale url'er for layers kan prioriteres over interne paths.

Vi har ingen andre interne paths som slutter på `/en|/nn/se` pdd, så denne endringen skal ikke påvirke noe eksisterende innhold.

## Oppsummering av hva som er gjort
- Tillater å sette en kort-url/customPath som overlapper med en intern _path
- Kort-url'er skal nå prioriteres over interne _path's ved resolving av requests fra frontend, dersom disse overlapper
- Paths med en gyldig locale-suffix (f.eks `/en`) skal nå alltid forsøkes å resolves til det aktuelle layeret, selv om det finnes en tilsvarende eksakt path i et annet layer