### PR TITLE
Begrense til å legge relatert innhold via målgrupper til produktsider

### DIFF
--- a/src/main/resources/site/content-types/content-page-with-sidemenus/content-page-with-sidemenus.xml
+++ b/src/main/resources/site/content-types/content-page-with-sidemenus/content-page-with-sidemenus.xml
@@ -37,7 +37,7 @@
                                     <occurrences minimum="1" maximum="1"/>
                                     <config>
                                         <service>contentSelector</service>
-                                        <param value="contentTypes">["no.nav.navno:content-page-with-sidemenus", "no.nav.navno:situation-page", "no.nav.navno:guide-page", "no.nav.navno:themed-article-page"]</param>
+                                        <param value="contentTypes">["no.nav.navno:content-page-with-sidemenus"]</param>
                                         <param value="selectorQuery">data.audience._selected="person"</param>
                                     </config>
                                 </input>
@@ -52,7 +52,7 @@
                                     <occurrences minimum="1" maximum="1"/>
                                     <config>
                                         <service>contentSelector</service>
-                                        <param value="contentTypes">["no.nav.navno:content-page-with-sidemenus", "no.nav.navno:situation-page", "no.nav.navno:guide-page", "no.nav.navno:themed-article-page"]</param>
+                                        <param value="contentTypes">["no.nav.navno:content-page-with-sidemenus"]</param>
                                         <param value="selectorQuery">data.audience._selected="employer"</param>
                                     </config>
                                 </input>
@@ -84,7 +84,7 @@
                                             <occurrences minimum="1" maximum="1"/>
                                             <config>
                                                 <service>contentSelector</service>
-                                                <param value="contentTypes">["no.nav.navno:content-page-with-sidemenus", "no.nav.navno:situation-page", "no.nav.navno:guide-page", "no.nav.navno:themed-article-page"]</param>
+                                                <param value="contentTypes">["no.nav.navno:content-page-with-sidemenus"]</param>
                                                 <param value="selectorQuery">data.audience._selected="provider"</param>
                                             </config>
                                         </input>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Fjerner innholdstyper bortsett fra produktside fra valgbar referanseliste for aktuelle målgrupper.


## Testing
Testet i dev
