### PR TITLE
Tweaker metatags for eksternt søk

### DIFF
--- a/src/main/resources/lib/search/external/document-builder/field-resolvers/audience.ts
+++ b/src/main/resources/lib/search/external/document-builder/field-resolvers/audience.ts
@@ -28,6 +28,8 @@ const pathSegmentToSearchAudience: Record<string, SearchDocumentAudience> = {
     samarbeid: 'samarbeidspartner',
 } as const;
 
+const pathSegmentAudienceExclusions: ReadonlySet<string> = new Set(['presse']);
+
 const getAudienceFromData = (content: ContentNode) => {
     const audience = content.data?.audience;
 
@@ -52,6 +54,12 @@ const getAudienceFromData = (content: ContentNode) => {
 
 const getAudienceFromPath = (content: ContentNode) => {
     const pathSegments = stripPathPrefix(content._path).split('/');
+
+    for (const segment of pathSegments) {
+        if (pathSegmentAudienceExclusions.has(segment)) {
+            return null;
+        }
+    }
 
     for (const segment of pathSegments) {
         const audienceFromPath = pathSegmentToSearchAudience[segment];

--- a/src/main/resources/lib/search/external/document-builder/field-resolvers/metatags.ts
+++ b/src/main/resources/lib/search/external/document-builder/field-resolvers/metatags.ts
@@ -39,7 +39,8 @@ const isAnalyse = (content: ContentNode) =>
 
 const isNavOgSamfunn = (content: ContentNode) =>
     content._path.startsWith('/content/www.nav.no/no/nav-og-samfunn') &&
-    !content._path.startsWith('/content/www.nav.no/no/nav-og-samfunn/statistikk');
+    !content._path.startsWith('/content/www.nav.no/no/nav-og-samfunn/statistikk') &&
+    !content._path.startsWith('/content/www.nav.no/no/nav-og-samfunn/samarbeid');
 
 const isPresse = (content: ContentNode) =>
     isPressemelding(content) ||
@@ -84,7 +85,6 @@ export const getSearchDocumentMetatags = (content: ContentNode) => {
     if (isNavOgSamfunn(content)) {
         metaTags.push('nav-og-samfunn');
     }
-
     if (canSetInformationTag && isInformation(content)) {
         metaTags.push('informasjon');
     }


### PR DESCRIPTION
- Ekskluderer `nav-og-samfunn/samarbeid`-mappa fra `nav-og-samfunn` tag.
- Setter ikke audience-felt på sider med `/presse/` url-segment