### PR TITLE
Tweaker metatags/audience tags for nytt søk

### DIFF
--- a/src/main/resources/lib/search/external/document-builder/field-resolvers/metatags.ts
+++ b/src/main/resources/lib/search/external/document-builder/field-resolvers/metatags.ts
@@ -4,7 +4,6 @@ import { getSearchDocumentContentType, SearchDocumentContentType } from './conte
 export type SearchDocumentMetatag =
     | 'nyhet'
     | 'pressemelding'
-    | 'nav-og-samfunn'
     | 'analyse'
     | 'statistikk'
     | 'presse'
@@ -37,20 +36,12 @@ const isStatistikk = (content: ContentNode) =>
 const isAnalyse = (content: ContentNode) =>
     content._path.startsWith('/content/www.nav.no/no/nav-og-samfunn/kunnskap');
 
-const isNavOgSamfunn = (content: ContentNode) =>
-    content._path.startsWith('/content/www.nav.no/no/nav-og-samfunn') &&
-    !content._path.startsWith('/content/www.nav.no/no/nav-og-samfunn/statistikk') &&
-    !content._path.startsWith('/content/www.nav.no/no/nav-og-samfunn/samarbeid');
-
 const isPresse = (content: ContentNode) =>
     isPressemelding(content) ||
     (isNyhet(content) &&
         (content._path.startsWith(
             '/content/www.nav.no/no/person/innhold-til-person-forside/nyheter'
         ) ||
-            content._path.startsWith(
-                '/content/www.nav.no/no/nav-og-samfunn/kunnskap/analyser-fra-nav'
-            ) ||
             !(
                 content._path.startsWith('/content/www.nav.no/no/person') ||
                 content._path.startsWith('/content/www.nav.no/no/bedrift') ||
@@ -81,9 +72,6 @@ export const getSearchDocumentMetatags = (content: ContentNode) => {
     if (isPresse(content)) {
         metaTags.push('presse');
         canSetInformationTag = false;
-    }
-    if (isNavOgSamfunn(content)) {
-        metaTags.push('nav-og-samfunn');
     }
     if (canSetInformationTag && isInformation(content)) {
         metaTags.push('informasjon');

--- a/src/main/resources/site/mixins/languages-legacy/languages-legacy.xml
+++ b/src/main/resources/site/mixins/languages-legacy/languages-legacy.xml
@@ -1,12 +1,10 @@
 <mixin>
     <form>
         <field-set>
-            <label>Legg til andre språkversjoner</label>
+            <label>Legacy språkversjoner (dersom layers ikke kan benyttes)</label>
             <items>
                 <input name="languages" type="ContentSelector">
                     <label>Legg til andre språkversjoner</label>
-                    <help-text>Kun relevant hvis det eksisterer flere språkversjoner av innholdet.
-                    </help-text>
                     <occurrences maximum="0" minimum="0"/>
                     <config>
                         <allowContentType>${app}:main-article</allowContentType>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Fjerner `nav-og-samfunn`
- Fjerner analyse-nyheter fra `presse`
- Inkluderer undermålgrupper i audience-arrayet