### PR TITLE
Lenkeliste: Støtte visning som punktliste

### DIFF
--- a/src/main/resources/site/parts/dynamic-link-list/dynamic-link-list-part-config.ts
+++ b/src/main/resources/site/parts/dynamic-link-list/dynamic-link-list-part-config.ts
@@ -11,9 +11,9 @@ export interface DynamicLinkListPartConfig {
   hideTitle: boolean;
 
   /**
-   * Lenker med chevron
+   * Vis listen som
    */
-  chevron: boolean;
+  listType: "default" | "chevron" | "bulletlist";
 
   /**
    * Lenker

--- a/src/main/resources/site/parts/dynamic-link-list/dynamic-link-list.xml
+++ b/src/main/resources/site/parts/dynamic-link-list/dynamic-link-list.xml
@@ -9,9 +9,15 @@
             <label>Skjul tittel</label>
             <default>unchecked</default>
         </input>
-        <input name="chevron" type="CheckBox">
-            <label>Lenker med chevron</label>
-            <default>unchecked</default>
+        <input name="listType" type="ComboBox">
+            <label>Vis listen som</label>
+            <occurrences minimum="1" maximum="1"/>
+            <config>
+                <option value="default">Vanlige lenker</option>
+                <option value="chevron">Lenker med chevron</option>
+                <option value="bulletlist">Lenker som punktliste</option>
+            </config>
+            <default>default</default>  
         </input>
         <option-set name="list">
             <label>Lenker</label>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Lenkeliste må ha tre type visninger: vanlig, chevron og punktliste (ny). Denne PR'en fjerner "Lenker med chevron" og lar redaktøren velge samme visning via en dropdown.

Det er 3-4 sider som faktisk har Lenkeliste hvor Lenker med chevron er slått på, så vi kan gå inn i etterkant av deploy og korrigere dette slik at disse sidene fortsatt viser lenkeliste med chevron.

## Testing
Testes i dev.