### PR TITLE
Fikser bugs ved scheduled invalidering av samme contentId i flere layers

### DIFF
--- a/src/main/resources/lib/cache/invalidate-special-content-types.ts
+++ b/src/main/resources/lib/cache/invalidate-special-content-types.ts
@@ -14,7 +14,7 @@ export const scheduleContactInformationInvalidation = (
     }
 
     const contactData = (content.data.contactType as any)[selected];
-    const customSpecialOpeningHours = contactData.specialOpeningHours?.custom;
+    const customSpecialOpeningHours = contactData?.specialOpeningHours?.custom;
     if (!customSpecialOpeningHours) {
         return;
     }

--- a/src/main/resources/lib/controllers/site-info-controller.ts
+++ b/src/main/resources/lib/controllers/site-info-controller.ts
@@ -2,7 +2,7 @@ import * as contentLib from '/lib/xp/content';
 import { Content } from '/lib/xp/content';
 import * as schedulerLib from '/lib/xp/scheduler';
 import httpClient from '/lib/http-client';
-import { URLS } from '../constants';
+import { CONTENT_ROOT_REPO_ID, URLS } from '../constants';
 import { clusterInfo, ClusterState, requestClusterInfo } from '../cluster-utils/cluster-api';
 import { getPrepublishJobName, getUnpublishJobName } from '../scheduling/scheduled-publish';
 import { RepoBranch } from '../../types/common';
@@ -44,20 +44,25 @@ type SiteInfo = {
 
 const isFuture = (dateTime?: string) => dateTime && Date.now() < new Date(dateTime).getTime();
 
+// TODO: support for content from layers
 const getPublishInfo = (content: Content): PublishInfo => {
     const publish: PublishInfo = {
         ...content.publish,
     };
 
     if (isFuture(publish.from)) {
-        const scheduledJob = schedulerLib.get({ name: getPrepublishJobName(content._id) });
+        const scheduledJob = schedulerLib.get({
+            name: getPrepublishJobName(content._id, CONTENT_ROOT_REPO_ID),
+        });
         if (scheduledJob) {
             publish.scheduledFrom = scheduledJob.schedule.value;
         }
     }
 
     if (isFuture(publish.to)) {
-        const scheduledJob = schedulerLib.get({ name: getUnpublishJobName(content._id) });
+        const scheduledJob = schedulerLib.get({
+            name: getUnpublishJobName(content._id, CONTENT_ROOT_REPO_ID),
+        });
         if (scheduledJob) {
             publish.scheduledTo = scheduledJob.schedule.value;
         }

--- a/src/main/resources/lib/scheduling/scheduled-publish-updater.ts
+++ b/src/main/resources/lib/scheduling/scheduled-publish-updater.ts
@@ -29,7 +29,9 @@ const schedulePrepublishTasks = () => {
                 return;
             }
 
-            const existingJob = schedulerLib.get({ name: getPrepublishJobName(content._id) });
+            const existingJob = schedulerLib.get({
+                name: getPrepublishJobName(content._id, repoId),
+            });
             if (!existingJob) {
                 logger.warning(
                     `Scheduled job for prepublish was missing for content ${content._path} in repo ${repoId}`
@@ -37,7 +39,7 @@ const schedulePrepublishTasks = () => {
             }
 
             scheduleCacheInvalidation({
-                jobName: getPrepublishJobName(content._id),
+                jobName: getPrepublishJobName(content._id, repoId),
                 id: content._id,
                 path: content._path,
                 repoId: repoId,
@@ -69,7 +71,9 @@ const scheduleUnpublishTasks = () => {
                 return;
             }
 
-            const existingJob = schedulerLib.get({ name: getUnpublishJobName(content._id) });
+            const existingJob = schedulerLib.get({
+                name: getUnpublishJobName(content._id, repoId),
+            });
             if (!existingJob) {
                 logger.warning(
                     `Scheduled job for unpublish was missing for content ${content._path} in repo ${repoId}`

--- a/src/main/resources/lib/scheduling/scheduled-publish.ts
+++ b/src/main/resources/lib/scheduling/scheduled-publish.ts
@@ -32,9 +32,11 @@ export const isPrepublished = (publishFrom?: string): publishFrom is string => {
     return publishFrom ? getUnixTimeFromDateTimeString(publishFrom) > Date.now() : false;
 };
 
-export const getPrepublishJobName = (contentId: string) => `prepublish-invalidate-${contentId}`;
+export const getPrepublishJobName = (contentId: string, repoId: string, suffix?: string) =>
+    `prepublish-invalidate-${contentId}-${repoId}${suffix ? `-${suffix}` : ''}`;
 
-export const getUnpublishJobName = (contentId: string) => `unpublish-${contentId}`;
+export const getUnpublishJobName = (contentId: string, repoId: string, suffix?: string) =>
+    `unpublish-${contentId}-${repoId}${suffix ? `-${suffix}` : ''}`;
 
 export const scheduleCacheInvalidation = ({
     jobName,
@@ -81,7 +83,7 @@ export const scheduleUnpublish = ({
     masterOnly?: boolean;
 }) => {
     createOrUpdateSchedule<UnpublishExpiredContent>({
-        jobName: getUnpublishJobName(id),
+        jobName: getUnpublishJobName(id, repoId),
         jobSchedule: {
             type: 'ONE_TIME',
             value: publishTo,
@@ -115,7 +117,7 @@ export const handleScheduledPublish = (nodeData: NodeEventData, eventType: strin
 
     if (isPrepublished(publish.from)) {
         scheduleCacheInvalidation({
-            jobName: getPrepublishJobName(id),
+            jobName: getPrepublishJobName(id, repo),
             id,
             path,
             repoId: repo,

--- a/src/main/resources/tasks/prepublish-cache-wipe/prepublish-cache-wipe.ts
+++ b/src/main/resources/tasks/prepublish-cache-wipe/prepublish-cache-wipe.ts
@@ -5,7 +5,9 @@ import { PrepublishCacheWipe } from '@xp-types/tasks/prepublish-cache-wipe';
 
 export const run = (params: PrepublishCacheWipe) => {
     const { id, path, repoId = CONTENT_ROOT_REPO_ID } = params;
-    logger.info(`Running task for cache invalidation of prepublished content - ${id} - ${path}`);
+    logger.info(
+        `Running task for cache invalidation of prepublished content - ${id} - ${repoId} - ${path}`
+    );
 
     invalidateCacheForNode({
         node: { id, path, branch: 'master', repo: repoId },


### PR DESCRIPTION
Bruker nå også repoId i key'en for jobbene, slik at invalidering i hvert repo får unik key