### PR TITLE
Returnerer alltid et array fra auditlog query

### DIFF
--- a/src/main/resources/admin/widgets/dashboard-content/utils/auditLogQuery.ts
+++ b/src/main/resources/admin/widgets/dashboard-content/utils/auditLogQuery.ts
@@ -2,6 +2,7 @@ import { getRepoConnection } from '../../../../lib/utils/repo-utils';
 import { UserKey } from '/lib/xp/auditlog';
 import { AuditLogArchived, AuditLogPublished, AuditLogUnpublished } from './types';
 import { Dayjs } from '/assets/dayjs/1.11.9/dayjs.min.js';
+import { forceArray } from '../../../../lib/utils/array-utils';
 
 const AUDITLOG_REPO_ID = 'system.auditlog';
 
@@ -62,7 +63,7 @@ export const getAuditLogEntries = <Type extends AuditLogQueryType>({
         })
         .hits.map((hit) => hit.id);
 
-    return repoConnection.get(hitIds) || [];
+    return forceArray(repoConnection.get(hitIds));
 };
 
 const queryTypeToLogType: Record<AuditLogQueryType, string> = {

--- a/src/main/resources/lib/utils/array-utils.ts
+++ b/src/main/resources/lib/utils/array-utils.ts
@@ -10,7 +10,7 @@ export const parseJsonToArray = <Type = unknown>(json: string): Type[] | null =>
     }
 };
 
-export const forceArray = <Type>(arrayOrNot?: Type | Type[]) => {
+export const forceArray = <Type>(arrayOrNot?: Type | Type[] | null) => {
     if (arrayOrNot === undefined || arrayOrNot === null) {
         return [];
     }


### PR DESCRIPTION
Fikser bugs som kan oppstå dersom `getAuditLogEntries` kun fir ett enkelt treff, og derfor ikke returnerer et array.