### PR TITLE
Aktuelle målgrupper: Kunne sette egen label for aandre samarbeidspartnere

### DIFF
--- a/.xp-codegen/site/content-types/content-page-with-sidemenus/index.d.ts
+++ b/.xp-codegen/site/content-types/content-page-with-sidemenus/index.d.ts
@@ -202,7 +202,7 @@ export type ContentPageWithSidemenus = {
                */
               other: {
                 /**
-                 * Egen benevnelse
+                 * Alternativ målgruppe
                  */
                 overrideLabel?: string;
               };

--- a/.xp-codegen/site/content-types/content-page-with-sidemenus/index.d.ts
+++ b/.xp-codegen/site/content-types/content-page-with-sidemenus/index.d.ts
@@ -200,7 +200,12 @@ export type ContentPageWithSidemenus = {
               /**
                * Andre samarbeidspartnere
                */
-              other: Record<string, unknown>;
+              other: {
+                /**
+                 * Egen benevnelse
+                 */
+                overrideLabel?: string;
+              };
             }
         >;
 

--- a/.xp-codegen/site/content-types/guide-page/index.d.ts
+++ b/.xp-codegen/site/content-types/guide-page/index.d.ts
@@ -215,7 +215,12 @@ export type GuidePage = {
               /**
                * Andre samarbeidspartnere
                */
-              other: Record<string, unknown>;
+              other: {
+                /**
+                 * Egen benevnelse
+                 */
+                overrideLabel?: string;
+              };
             }
         >;
 

--- a/.xp-codegen/site/content-types/guide-page/index.d.ts
+++ b/.xp-codegen/site/content-types/guide-page/index.d.ts
@@ -217,7 +217,7 @@ export type GuidePage = {
                */
               other: {
                 /**
-                 * Egen benevnelse
+                 * Alternativ målgruppe
                  */
                 overrideLabel?: string;
               };

--- a/.xp-codegen/site/content-types/themed-article-page/index.d.ts
+++ b/.xp-codegen/site/content-types/themed-article-page/index.d.ts
@@ -220,7 +220,12 @@ export type ThemedArticlePage = {
               /**
                * Andre samarbeidspartnere
                */
-              other: Record<string, unknown>;
+              other: {
+                /**
+                 * Egen benevnelse
+                 */
+                overrideLabel?: string;
+              };
             }
         >;
 

--- a/.xp-codegen/site/content-types/themed-article-page/index.d.ts
+++ b/.xp-codegen/site/content-types/themed-article-page/index.d.ts
@@ -222,7 +222,7 @@ export type ThemedArticlePage = {
                */
               other: {
                 /**
-                 * Egen benevnelse
+                 * Alternativ målgruppe
                  */
                 overrideLabel?: string;
               };

--- a/.xp-codegen/site/mixins/alternative-audience/index.d.ts
+++ b/.xp-codegen/site/mixins/alternative-audience/index.d.ts
@@ -116,7 +116,12 @@ export type AlternativeAudience = {
               /**
                * Andre samarbeidspartnere
                */
-              other: Record<string, unknown>;
+              other: {
+                /**
+                 * Alternativt navn
+                 */
+                overrideLabel?: string;
+              };
             }
         >;
 

--- a/.xp-codegen/site/mixins/alternative-audience/index.d.ts
+++ b/.xp-codegen/site/mixins/alternative-audience/index.d.ts
@@ -118,7 +118,7 @@ export type AlternativeAudience = {
                */
               other: {
                 /**
-                 * Alternativt navn
+                 * Alternativ målgruppe
                  */
                 overrideLabel?: string;
               };

--- a/src/main/resources/lib/guillotine/queries/fragments/content-types/contentPageWithSidemenusFragment.graphql
+++ b/src/main/resources/lib/guillotine/queries/fragments/content-types/contentPageWithSidemenusFragment.graphql
@@ -26,7 +26,10 @@ fragment contentContentPageWithSidemenus on no_nav_navno_ContentPageWithSidemenu
             }
             provider {
                 providerList {
-                    providerAudience
+                    providerAudience {
+                        name
+                        overrideLabel
+                    }
                     targetPage {
                         ...contentCommon
                     }

--- a/src/main/resources/lib/guillotine/queries/fragments/content-types/guidePageFragment.graphql
+++ b/src/main/resources/lib/guillotine/queries/fragments/content-types/guidePageFragment.graphql
@@ -25,7 +25,10 @@ fragment contentGuidePage on no_nav_navno_GuidePage {
             }
             provider {
                 providerList {
-                    providerAudience
+                    providerAudience {
+                        name
+                        overrideLabel
+                    }
                     targetPage {
                         ...contentCommon
                     }

--- a/src/main/resources/lib/guillotine/queries/fragments/content-types/themedArticlePageFragment.graphql
+++ b/src/main/resources/lib/guillotine/queries/fragments/content-types/themedArticlePageFragment.graphql
@@ -26,7 +26,10 @@ fragment contentThemedArticlePage on no_nav_navno_ThemedArticlePage {
             }
             provider {
                 providerList {
-                    providerAudience
+                    providerAudience {
+                        name
+                        overrideLabel
+                    }
                     targetPage {
                         ...contentCommon
                     }

--- a/src/main/resources/site/mixins/alternative-audience/alternative-audience.xml
+++ b/src/main/resources/site/mixins/alternative-audience/alternative-audience.xml
@@ -54,7 +54,15 @@
                                                 <option name="administrator"><label>Bostyrer</label></option>
                                                 <option name="measures_organizer"><label>Tiltaksarrangør</label></option>
                                                 <option name="aid_supplier"><label>Hjelpemiddelformidler</label></option>
-                                                <option name="other"><label>Andre samarbeidspartnere</label></option>
+                                                <option name="other">
+                                                    <label>Andre samarbeidspartnere</label>
+                                                    <items>
+                                                        <input name="overrideLabel" type="TextLine">
+                                                            <label>Alternativt navn</label>
+                                                            <occurrences minimum="0" maximum="1"/>
+                                                        </input>
+                                                    </items>
+                                                </option>
                                             </options>
                                         </option-set>
                                         <input name="targetPage" type="CustomSelector">

--- a/src/main/resources/site/mixins/alternative-audience/alternative-audience.xml
+++ b/src/main/resources/site/mixins/alternative-audience/alternative-audience.xml
@@ -58,7 +58,8 @@
                                                     <label>Andre samarbeidspartnere</label>
                                                     <items>
                                                         <input name="overrideLabel" type="TextLine">
-                                                            <label>Alternativt navn</label>
+                                                            <label>Alternativ målgruppe</label>
+                                                            <help-text>For eksempel lese- og sekretærhjelp eller frilandstolk.</help-text>
                                                             <occurrences minimum="0" maximum="1"/>
                                                         </input>
                                                     </items>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Man må kunne sette en egen label/navn hvis man har valgt "andre samarbeidspartnere" som aktuell målgruppe.
Denne PR'en gjør at frontend håndterer både string og objekt for valgt samarbeidspartner.

## Testing
Testet i q6
