### PR TITLE
Fjerner innstillinger for varehylle i flex-cols

### DIFF
--- a/.xp-codegen/site/layouts/situation-flex-cols/index.d.ts
+++ b/.xp-codegen/site/layouts/situation-flex-cols/index.d.ts
@@ -21,38 +21,6 @@ export type SituationFlexCols = {
   toggleCopyButton: boolean;
 
   /**
-   * Innstilling for varehyller
-   */
-  shelf?:
-    | {
-        /**
-         * Selected
-         */
-        _selected: "products";
-
-        /**
-         * Produkter
-         */
-        products: {
-          /**
-           * Prioritering
-           */
-          priority?: "primary" | "secondary" | "tertiary";
-        };
-      }
-    | {
-        /**
-         * Selected
-         */
-        _selected: "providers";
-
-        /**
-         * Samarbeidspartner
-         */
-        providers: Record<string, unknown>;
-      };
-
-  /**
    * Antall kolonner ved full skjermbredde
    */
   numCols?: number;

--- a/src/main/resources/site/layouts/situation-flex-cols/situation-flex-cols.xml
+++ b/src/main/resources/site/layouts/situation-flex-cols/situation-flex-cols.xml
@@ -3,31 +3,6 @@
     <description>Responsive flexbox-kolonner</description>
     <form>
         <mixin name="header-with-anchor"/>
-        <option-set name="shelf">
-            <label>Innstilling for varehyller</label>
-            <help-text>Brukes kun hvis dette er en type varehylle.</help-text>
-            <options minimum="1" maximum="1">
-                <option name="products">
-                    <label>Produkter</label>
-                    <help-text>Varehyllen skal inneholde kort til andre produkter i NAV</help-text>
-                    <items>
-                        <input type="ComboBox" name="priority">
-                            <label>Prioritering</label>
-                            <config>
-                                <option value="primary">Primær</option>
-                                <option value="secondary">Sekundær</option>
-                                <option value="tertiary">Tertier</option>
-                            </config>
-                            <default>primary</default>
-                        </input>
-                    </items>
-                </option>
-                <option name="providers">
-                    <label>Samarbeidspartner</label>
-                    <help-text>Varehyllen skal inneholde kort eksterne samarbeidspartnere eller andre offentlige tjenester.</help-text>
-                </option>
-            </options>
-        </option-set>
         <input type="Long" name="numCols">
             <label>Antall kolonner ved full skjermbredde</label>
             <config>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Intensjonen med innstillingen var å kunne angi at en flex-col er en varehylle og hvilken type varehylle den er. Jeg har søkt igjennom og gjort en query etter sider hvor denne funksjonen er brukt, og finner ingen. Har også bekreftet med Tuva at den kan fjernes.

## Testing
Testes i dev