### PR TITLE
Fjerner enhet.sosialeTjenester feltet fra legacy kontor-sider

### DIFF
--- a/config/dev/no.nav.navno.cfg
+++ b/config/dev/no.nav.navno.cfg
@@ -1,5 +1,3 @@
 env=dev
-norg2=https://api-gw.oera.no/norg2/api/v1/enhet/kontaktinformasjon/organisering/all
 norg2ApiKey=
 norg2ConsumerId=navno-enonicxp
-xpOrigin=https://www-q1.nav.no

--- a/config/localhost/no.nav.navno.cfg
+++ b/config/localhost/no.nav.navno.cfg
@@ -1,6 +1,4 @@
 env=localhost
-norg2=http://localhost:5000
 norg2ApiKey=myKey
 norg2ConsumerId=myConsumerId
-xpOrigin=http://localhost:8080
 serviceSecret=dummyToken

--- a/config/p/no.nav.navno.cfg
+++ b/config/p/no.nav.navno.cfg
@@ -1,5 +1,3 @@
 env=p
-norg2=https://api-gw.oera.no/norg2/api/v1/enhet/kontaktinformasjon/organisering/all
 norg2ApiKey=
 norg2ConsumerId=navno-enonicxp
-xpOrigin=https://www.nav.no

--- a/config/q6/no.nav.navno.cfg
+++ b/config/q6/no.nav.navno.cfg
@@ -1,5 +1,3 @@
 env=q6
-norg2=https://api-gw.oera.no/norg2/api/v1/enhet/kontaktinformasjon/organisering/all
 norg2ApiKey=
 norg2ConsumerId=navno-enonicxp
-xpOrigin=https://www-q6.nav.no

--- a/src/main/resources/lib/constants.ts
+++ b/src/main/resources/lib/constants.ts
@@ -40,6 +40,14 @@ const norgOfficeInformationApiUrl: EnvRecord = {
     localhost: 'https://norg2.dev-fss-pub.nais.io/norg2/api/v2/enhet/kontaktinformasjoner',
 } as const;
 
+const norgLegacyOfficeInformationApiUrl: EnvRecord = {
+    p: 'https://norg2.prod-fss-pub.nais.io/norg2/api/v1/enhet/kontaktinformasjon/organisering/all',
+    dev: 'https://norg2.dev-fss-pub.nais.io/norg2/api/v1/enhet/kontaktinformasjon/organisering/all',
+    q6: 'https://norg2.dev-fss-pub.nais.io/norg2/api/v1/enhet/kontaktinformasjon/organisering/all',
+    localhost:
+        'https://norg2.prod-fss-pub.nais.io/norg2/api/v1/enhet/kontaktinformasjon/organisering/all',
+} as const;
+
 const norgLocalOfficeApiUrl: EnvRecord = {
     p: 'https://norg2.prod-fss-pub.nais.io/norg2/api/v2/navlokalkontor?statusFilter=AKTIV',
     dev: 'https://norg2.dev-fss-pub.nais.io/norg2/api/v2/navlokalkontor?statusFilter=AKTIV',
@@ -68,6 +76,7 @@ export const URLS = {
     PORTAL_ADMIN_ORIGIN: portalAdminOrigins[env],
     NORG_OFFICE_OVERVIEW_API_URL: norgOfficeOverviewApiUrl[env],
     NORG_OFFICE_INFORMATION_API_URL: norgOfficeInformationApiUrl[env],
+    NORG_LEGACY_OFFICE_INFORMATION_API_URL: norgLegacyOfficeInformationApiUrl[env],
     NORG_LOCAL_OFFICE_API_URL: norgLocalOfficeApiUrl[env],
     SEARCH_API_URL: searchApiUrls[env],
 } as const;

--- a/src/main/resources/lib/constants.ts
+++ b/src/main/resources/lib/constants.ts
@@ -45,7 +45,7 @@ const norgLegacyOfficeInformationApiUrl: EnvRecord = {
     dev: 'https://norg2.dev-fss-pub.nais.io/norg2/api/v1/enhet/kontaktinformasjon/organisering/all',
     q6: 'https://norg2.dev-fss-pub.nais.io/norg2/api/v1/enhet/kontaktinformasjon/organisering/all',
     localhost:
-        'https://norg2.prod-fss-pub.nais.io/norg2/api/v1/enhet/kontaktinformasjon/organisering/all',
+        'https://norg2.dev-fss-pub.nais.io/norg2/api/v1/enhet/kontaktinformasjon/organisering/all',
 } as const;
 
 const norgLocalOfficeApiUrl: EnvRecord = {

--- a/src/main/resources/types/global.d.ts
+++ b/src/main/resources/types/global.d.ts
@@ -3,12 +3,8 @@ declare const app: {
     version: string;
     config: {
         env: 'p' | 'dev' | 'q6' | 'localhost';
-        norg2: string;
         norg2ApiKey: string;
         norg2ConsumerId: string;
-        frontendOrigin: string;
-        xpOrigin: string;
-        revalidatorProxyOrigin: string;
         serviceSecret: string;
         searchApiKey: string;
     };


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Dette feltet kan inneholde data kun ment for intern bruk, og bør ikke risikere å eksponeres til publikum.

Legger også inn norg2 legacy api url i appen, fremfor å sette den i config-fil på serverne.