### PR TITLE
Sletter one-time scheduler jobber

### DIFF
--- a/.xp-codegen/site/content-types/area-page/index.d.ts
+++ b/.xp-codegen/site/content-types/area-page/index.d.ts
@@ -175,7 +175,7 @@ export type AreaPage = {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets) i Google-søk
+   * Ikke vis "tilfeldige" utdrag (snippets) i Google-søk
    */
   nosnippet: boolean;
 }

--- a/.xp-codegen/site/content-types/content-page-with-sidemenus/index.d.ts
+++ b/.xp-codegen/site/content-types/content-page-with-sidemenus/index.d.ts
@@ -313,7 +313,7 @@ export type ContentPageWithSidemenus = {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets) i Google-søk
+   * Ikke vis "tilfeldige" utdrag (snippets) i Google-søk
    */
   nosnippet: boolean;
 }

--- a/.xp-codegen/site/content-types/current-topic-page/index.d.ts
+++ b/.xp-codegen/site/content-types/current-topic-page/index.d.ts
@@ -130,7 +130,7 @@ export type CurrentTopicPage = {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets) i Google-søk
+   * Ikke vis "tilfeldige" utdrag (snippets) i Google-søk
    */
   nosnippet: boolean;
 }

--- a/.xp-codegen/site/content-types/dynamic-page/index.d.ts
+++ b/.xp-codegen/site/content-types/dynamic-page/index.d.ts
@@ -41,7 +41,7 @@ export type DynamicPage = {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets) i Google-søk
+   * Ikke vis "tilfeldige" utdrag (snippets) i Google-søk
    */
   nosnippet: boolean;
 

--- a/.xp-codegen/site/content-types/front-page-nested/index.d.ts
+++ b/.xp-codegen/site/content-types/front-page-nested/index.d.ts
@@ -110,7 +110,7 @@ export type FrontPageNested = {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets) i Google-søk
+   * Ikke vis "tilfeldige" utdrag (snippets) i Google-søk
    */
   nosnippet: boolean;
 }

--- a/.xp-codegen/site/content-types/front-page/index.d.ts
+++ b/.xp-codegen/site/content-types/front-page/index.d.ts
@@ -110,7 +110,7 @@ export type FrontPage = {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets) i Google-søk
+   * Ikke vis "tilfeldige" utdrag (snippets) i Google-søk
    */
   nosnippet: boolean;
 }

--- a/.xp-codegen/site/content-types/generic-page/index.d.ts
+++ b/.xp-codegen/site/content-types/generic-page/index.d.ts
@@ -130,7 +130,7 @@ export type GenericPage = {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets) i Google-søk
+   * Ikke vis "tilfeldige" utdrag (snippets) i Google-søk
    */
   nosnippet: boolean;
 }

--- a/.xp-codegen/site/content-types/guide-page/index.d.ts
+++ b/.xp-codegen/site/content-types/guide-page/index.d.ts
@@ -313,7 +313,7 @@ export type GuidePage = {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets) i Google-søk
+   * Ikke vis "tilfeldige" utdrag (snippets) i Google-søk
    */
   nosnippet: boolean;
 }

--- a/.xp-codegen/site/content-types/main-article/index.d.ts
+++ b/.xp-codegen/site/content-types/main-article/index.d.ts
@@ -216,7 +216,7 @@ export type MainArticle = {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets) i Google-søk
+   * Ikke vis "tilfeldige" utdrag (snippets) i Google-søk
    */
   nosnippet: boolean;
 

--- a/.xp-codegen/site/content-types/office-editorial-page/index.d.ts
+++ b/.xp-codegen/site/content-types/office-editorial-page/index.d.ts
@@ -41,7 +41,7 @@ export type OfficeEditorialPage = {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets) i Google-søk
+   * Ikke vis "tilfeldige" utdrag (snippets) i Google-søk
    */
   nosnippet: boolean;
 }

--- a/.xp-codegen/site/content-types/overview/index.d.ts
+++ b/.xp-codegen/site/content-types/overview/index.d.ts
@@ -101,7 +101,7 @@ export type Overview = {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets) i Google-søk
+   * Ikke vis "tilfeldige" utdrag (snippets) i Google-søk
    */
   nosnippet: boolean;
 

--- a/.xp-codegen/site/content-types/page-list/index.d.ts
+++ b/.xp-codegen/site/content-types/page-list/index.d.ts
@@ -86,7 +86,7 @@ export type PageList = {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets) i Google-søk
+   * Ikke vis "tilfeldige" utdrag (snippets) i Google-søk
    */
   nosnippet: boolean;
 

--- a/.xp-codegen/site/content-types/publishing-calendar/index.d.ts
+++ b/.xp-codegen/site/content-types/publishing-calendar/index.d.ts
@@ -21,7 +21,7 @@ export type PublishingCalendar = {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets) i Google-søk
+   * Ikke vis "tilfeldige" utdrag (snippets) i Google-søk
    */
   nosnippet: boolean;
 

--- a/.xp-codegen/site/content-types/section-page/index.d.ts
+++ b/.xp-codegen/site/content-types/section-page/index.d.ts
@@ -116,7 +116,7 @@ export type SectionPage = {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets) i Google-søk
+   * Ikke vis "tilfeldige" utdrag (snippets) i Google-søk
    */
   nosnippet: boolean;
 

--- a/.xp-codegen/site/content-types/situation-page/index.d.ts
+++ b/.xp-codegen/site/content-types/situation-page/index.d.ts
@@ -145,7 +145,7 @@ export type SituationPage = {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets) i Google-søk
+   * Ikke vis "tilfeldige" utdrag (snippets) i Google-søk
    */
   nosnippet: boolean;
 }

--- a/.xp-codegen/site/content-types/themed-article-page/index.d.ts
+++ b/.xp-codegen/site/content-types/themed-article-page/index.d.ts
@@ -313,7 +313,7 @@ export type ThemedArticlePage = {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets) i Google-søk
+   * Ikke vis "tilfeldige" utdrag (snippets) i Google-søk
    */
   nosnippet: boolean;
 }

--- a/.xp-codegen/site/content-types/transport-page/index.d.ts
+++ b/.xp-codegen/site/content-types/transport-page/index.d.ts
@@ -66,7 +66,7 @@ export type TransportPage = {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets) i Google-søk
+   * Ikke vis "tilfeldige" utdrag (snippets) i Google-søk
    */
   nosnippet: boolean;
 

--- a/.xp-codegen/site/mixins/dynamic-page-common/index.d.ts
+++ b/.xp-codegen/site/mixins/dynamic-page-common/index.d.ts
@@ -41,7 +41,7 @@ export type DynamicPageCommon = {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets) i Google-søk
+   * Ikke vis "tilfeldige" utdrag (snippets) i Google-søk
    */
   nosnippet: boolean;
 }

--- a/.xp-codegen/site/mixins/seo/index.d.ts
+++ b/.xp-codegen/site/mixins/seo/index.d.ts
@@ -16,7 +16,7 @@ export type Seo = {
   noindex: boolean;
 
   /**
-   * Ikke vis utdrag (snippets) i Google-søk
+   * Ikke vis "tilfeldige" utdrag (snippets) i Google-søk
    */
   nosnippet: boolean;
 }

--- a/src/main/resources/lib/scheduling/schedule-cleanup.ts
+++ b/src/main/resources/lib/scheduling/schedule-cleanup.ts
@@ -5,8 +5,6 @@ import { createOrUpdateSchedule } from './schedule-job';
 import { APP_DESCRIPTOR } from '../constants';
 import { SchedulerCleanup } from '@xp-types/tasks/scheduler-cleanup';
 
-const ONE_DAY_MS = 24 * 60 * 60 * 1000;
-
 // Removes expired one-time jobs
 export const runSchedulerCleanup = (dryRun?: boolean) => {
     const repoConnection = getRepoConnection({
@@ -15,7 +13,7 @@ export const runSchedulerCleanup = (dryRun?: boolean) => {
         asAdmin: true,
     });
 
-    const oneDayAgo = new Date(Date.now() - ONE_DAY_MS).toISOString();
+    const now = new Date().toISOString();
 
     const jobsToPrune = batchedNodeQuery({
         queryParams: {
@@ -30,9 +28,14 @@ export const runSchedulerCleanup = (dryRun?: boolean) => {
                             },
                         },
                         {
+                            exists: {
+                                field: 'lastRun',
+                            },
+                        },
+                        {
                             range: {
                                 field: 'calendar.value',
-                                lt: oneDayAgo,
+                                lt: now,
                             },
                         },
                     ],

--- a/src/main/resources/lib/scheduling/schedule-cleanup.ts
+++ b/src/main/resources/lib/scheduling/schedule-cleanup.ts
@@ -1,0 +1,75 @@
+import { getRepoConnection } from '../utils/repo-utils';
+import { batchedNodeQuery } from '../utils/batched-query';
+import { logger } from '../utils/logging';
+import { createOrUpdateSchedule } from './schedule-job';
+import { APP_DESCRIPTOR } from '../constants';
+import { SchedulerCleanup } from '@xp-types/tasks/scheduler-cleanup';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+// Removes expired one-time jobs
+export const runSchedulerCleanup = (dryRun?: boolean) => {
+    const repoConnection = getRepoConnection({
+        repoId: 'system.scheduler',
+        branch: 'master',
+        asAdmin: true,
+    });
+
+    const oneDayAgo = new Date(Date.now() - ONE_DAY_MS).toISOString();
+
+    const jobsToPrune = batchedNodeQuery({
+        queryParams: {
+            count: 10000,
+            query: {
+                boolean: {
+                    must: [
+                        {
+                            like: {
+                                field: 'calendar.type',
+                                value: 'ONE_TIME',
+                            },
+                        },
+                        {
+                            range: {
+                                field: 'calendar.value',
+                                lt: oneDayAgo,
+                            },
+                        },
+                    ],
+                },
+            },
+        },
+        repo: repoConnection,
+    }).hits;
+
+    const numExpiredJobs = jobsToPrune.length;
+
+    if (numExpiredJobs === 0) {
+        logger.info('No expired jobs found');
+        return;
+    }
+
+    logger.info(`Found ${jobsToPrune.length} expired jobs to prune`);
+
+    if (dryRun) {
+        logger.info('Skipping pruning as dryRun flag was set');
+        return;
+    }
+
+    const result = repoConnection.delete(jobsToPrune.map((job) => job.id));
+
+    logger.info(`Pruned ${result.length} / ${jobsToPrune.length} expired jobs`);
+};
+
+export const activateSchedulerCleanupSchedule = () => {
+    createOrUpdateSchedule<SchedulerCleanup>({
+        jobName: 'scheduler-cleanup',
+        jobSchedule: {
+            type: 'CRON',
+            value: '0 7 * * *',
+            timeZone: 'GMT+2:00',
+        },
+        taskDescriptor: `${APP_DESCRIPTOR}:scheduler-cleanup`,
+        taskConfig: {},
+    });
+};

--- a/src/main/resources/main.ts
+++ b/src/main/resources/main.ts
@@ -21,6 +21,7 @@ import { activateLayersEventListeners } from './lib/localization/publish-events'
 import { activateContentUpdateListener } from './lib/contentUpdate/content-update-listener';
 import { activateExternalSearchIndexEventHandlers } from './lib/search/event-handlers';
 import { initializeMainDatanodeSelection } from './lib/cluster-utils/main-datanode';
+import { activateSchedulerCleanupSchedule } from './lib/scheduling/schedule-cleanup';
 
 updateClusterInfo();
 initLayersData();
@@ -42,6 +43,7 @@ activateContentListItemUnpublishedListener();
 activateCustomPathNodeListeners();
 activateExternalSearchIndexEventHandlers();
 activateContentUpdateListener();
+activateSchedulerCleanupSchedule();
 
 // This is somewhat annoying for local development, as it will run a fairly heavy task and spam
 // the logs when generating the sitemap. This happens on every redeploy of the app.

--- a/src/main/resources/tasks/scheduler-cleanup/scheduler-cleanup.ts
+++ b/src/main/resources/tasks/scheduler-cleanup/scheduler-cleanup.ts
@@ -1,0 +1,7 @@
+import { logger } from '../../lib/utils/logging';
+import { runSchedulerCleanup } from '../../lib/scheduling/schedule-cleanup';
+
+export const run = () => {
+    logger.info('Running scheduler cleanup task');
+    runSchedulerCleanup();
+};

--- a/src/main/resources/tasks/scheduler-cleanup/scheduler-cleanup.xml
+++ b/src/main/resources/tasks/scheduler-cleanup/scheduler-cleanup.xml
@@ -1,0 +1,3 @@
+<task>
+    <description>Prune expired one-time scheduler jobs</description>
+</task>

--- a/src/main/resources/webapp/webapp.ts
+++ b/src/main/resources/webapp/webapp.ts
@@ -11,6 +11,7 @@ import { userIsAdmin } from '../lib/utils/auth-utils';
 import { externalSearchUpdateAll } from '../lib/search/update-all';
 import { URLS } from '../lib/constants';
 import { fetchAndUpdateOfficeInfo } from '../lib/office-pages/_legacy-office-information/legacy-office-update';
+import { runSchedulerCleanup } from '../lib/scheduling/schedule-cleanup';
 
 type ActionsMap = Record<string, { description: string; callback: () => any }>;
 
@@ -41,6 +42,10 @@ const validActions: ActionsMap = {
     removeUnpublishedFromContentLists: {
         description: 'Fjern avpublisert innhold fra alle innholdslister',
         callback: removeUnpublishedFromAllContentLists,
+    },
+    schedulerCleanup: {
+        description: 'Fjern expired scheduler jobs (kjøres normalt automatisk hver morgen)',
+        callback: () => runSchedulerCleanup(),
     },
     ...(!!URLS.SEARCH_API_URL && {
         updateAllSearchNodesExternal: {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Kjører en daglig cleanup av one-time jobber i scheduleren som allerede har kjørt. Ser ikke ut som dette gjøres automatisk på noe vis, og Enonic har en intern sjekk på alle jobbene, som kjøres hvert sekund. Denne bruker en del CPU på de >6000 jobbene vi har i dag, hvor 5300 av de egentlig ikke er aktive.