### PR TITLE
Fikser bug som hindret automatisk avpublisering av expired content

### DIFF
--- a/src/main/resources/lib/scheduling/schedule-cleanup.ts
+++ b/src/main/resources/lib/scheduling/schedule-cleanup.ts
@@ -5,6 +5,8 @@ import { createOrUpdateSchedule } from './schedule-job';
 import { APP_DESCRIPTOR } from '../constants';
 import { SchedulerCleanup } from '@xp-types/tasks/scheduler-cleanup';
 
+const ONE_MONTH_MS = 30 * 24 * 60 * 60 * 1000;
+
 // Removes expired one-time jobs
 export const runSchedulerCleanup = (dryRun?: boolean) => {
     const repoConnection = getRepoConnection({
@@ -13,7 +15,8 @@ export const runSchedulerCleanup = (dryRun?: boolean) => {
         asAdmin: true,
     });
 
-    const now = new Date().toISOString();
+    // Keep jobs up to a month old in case we need to debug jobs that ran recently
+    const oneMonthAgo = new Date(Date.now() - ONE_MONTH_MS).toISOString();
 
     const jobsToPrune = batchedNodeQuery({
         queryParams: {
@@ -35,7 +38,7 @@ export const runSchedulerCleanup = (dryRun?: boolean) => {
                         {
                             range: {
                                 field: 'calendar.value',
-                                lt: now,
+                                lt: oneMonthAgo,
                             },
                         },
                     ],

--- a/src/main/resources/tasks/unpublish-expired-content/unpublish-expired-content.ts
+++ b/src/main/resources/tasks/unpublish-expired-content/unpublish-expired-content.ts
@@ -1,4 +1,5 @@
 import * as contentLib from '/lib/xp/content';
+import { Content } from '/lib/xp/content';
 import { scheduleUnpublish } from '../../lib/scheduling/scheduled-publish';
 import { logger } from '../../lib/utils/logging';
 import { getLayersData } from '../../lib/localization/layers-data';
@@ -6,25 +7,26 @@ import { runInLocaleContext } from '../../lib/localization/locale-context';
 import { CONTENT_ROOT_REPO_ID } from '../../lib/constants';
 import { getUnixTimeFromDateTimeString } from '../../lib/utils/datetime-utils';
 import { UnpublishExpiredContent } from '@xp-types/tasks/unpublish-expired-content';
-import { runInContext } from '../../lib/context/run-in-context';
+import { getRepoConnection } from '../../lib/utils/repo-utils';
 
 export const run = (params: UnpublishExpiredContent) => {
     const { id, path, repoId = CONTENT_ROOT_REPO_ID } = params;
 
-    logger.info(`Running task for unpublishing expired content - ${id} - ${path}`);
+    const contentInfo = `${id} [${repoId}]`;
 
-    const getContent = () =>
-        runInContext({ branch: 'master', repository: repoId }, () => contentLib.get({ key: id }));
+    logger.info(`Running task for unpublishing expired content - ${contentInfo}`);
 
-    const content = getContent();
+    const repo = getRepoConnection({ repoId, branch: 'master' });
+
+    const content = repo.get<Content>({ key: id });
     if (!content) {
-        logger.error(`Content ${id} not found in master - aborting unpublish task`);
+        logger.error(`Content ${contentInfo} not found in master - aborting unpublish task`);
         return;
     }
 
     const publishTo = content.publish?.to;
     if (!publishTo) {
-        logger.info(`Content ${id} is no longer set to expire - aborting unpublish task`);
+        logger.info(`Content ${contentInfo} is no longer set to expire - aborting unpublish task`);
         return;
     }
 
@@ -32,7 +34,7 @@ export const run = (params: UnpublishExpiredContent) => {
     const publishToTime = getUnixTimeFromDateTimeString(publishTo);
     if (currentTime < publishToTime) {
         logger.info(
-            `Content ${id} has not yet expired - rescheduling unpublish task (current time: ${currentTime} - expire time: ${publishToTime})`
+            `Content ${contentInfo} has not yet expired - rescheduling unpublish task (current time: ${currentTime} - expire time: ${publishToTime})`
         );
         scheduleUnpublish({ id, path, repoId, publishTo });
         return;
@@ -46,17 +48,17 @@ export const run = (params: UnpublishExpiredContent) => {
         if (unpublished && unpublished.length > 0) {
             logger.info(`Unpublished content: ${unpublished.join(', ')}`);
             if (unpublished.length > 1) {
-                logger.error(`Unexpectedly unpublished multiple contents with id ${id}`);
+                logger.error(`Unexpectedly unpublished multiple contents: ${contentInfo}`);
             }
         } else {
-            const contentNow = getContent();
+            const contentNow = repo.get<Content>({ key: id });
             if (contentNow) {
-                logger.critical(`Could not unpublish ${id} - unknown error`);
+                logger.critical(`Could not unpublish ${contentInfo} - unknown error`);
             } else {
-                logger.warning(`Could not unpublish ${id} as it was already unpublished`);
+                logger.warning(`Could not unpublish ${contentInfo} as it was already unpublished`);
             }
         }
     } catch (e) {
-        logger.critical(`Error while unpublishing ${id} - ${e}`);
+        logger.critical(`Error while unpublishing ${contentInfo} - ${e}`);
     }
 };


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Kom til skade for å bruke content api'et for å hente ut expired content for scheduled avpublisering ved en refactoring for en liten stund siden. Dette kan ikke (by design) hente ut innhold som er expired, må derfor bruke node api'et her. 😅 

Tar også å beholder expired scheduler-jobber en måned tilbake i tid, for å gjøre det enklere å feilsøke hvis noe scheduler-relatert feiler.