### PR TITLE
Legger til støtte for skjemadetaljer i et fragment i en processed_html

### DIFF
--- a/src/main/resources/lib/guillotine/queries/fragments/richText/macrosFragment.graphql
+++ b/src/main/resources/lib/guillotine/queries/fragments/richText/macrosFragment.graphql
@@ -163,6 +163,28 @@ fragment html_fragmentMacro on Macro {
                                 }
                             }
                         }
+                        form_details {
+                            targetFormDetails {
+                                ... on no_nav_navno_FormDetails {
+                                    dataAsJson
+                                    data {
+                                        ingress(processHtml: { type: server }) {
+                                            ... on RichText {
+                                                processedHtml
+                                                macros {
+                                                    ...macros
+                                                }
+                                            }
+                                        }
+                                        ...formTypeMixin
+                                    }
+                                }
+                            }
+                            showTitle
+                            showIngress
+                            showApplications
+                            showAddendums
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Pga sirkulær nøsting måtte vi skrive en litt hacky query for å få resolvet processed_html inne i en macro inne i et fragment. Denne queryen støttet ikke dersom det lå en skjemadetalj inne i html-innholdet.

Begrensningen i denne fiksen er da at skjemadetaljen ikke kan inneholde nok en fragment med html-innhold. Andre makroer slik som global verdi skal derimot støttes.

## Testing
Testes i dev

