### PR TITLE
Sjekker om innhold er prepublisert før det bygges som søkedokument

### DIFF
--- a/src/main/resources/lib/search/document-builder/document-builder.ts
+++ b/src/main/resources/lib/search/document-builder/document-builder.ts
@@ -5,6 +5,7 @@ import {
     getContentLocaleRedirectTarget,
     isContentNoIndex,
     isContentPreviewOnly,
+    isContentPrepublished,
 } from '../../utils/content-utils';
 import { getNestedValues } from '../../utils/object-utils';
 import { getExternalSearchConfig } from '../config';
@@ -188,6 +189,7 @@ const isExcludedContent = (content: ContentNode) => {
     }
 
     if (
+        isContentPrepublished(content) ||
         isContentNoIndex(content) ||
         isContentPreviewOnly(content) ||
         getContentLocaleRedirectTarget(content) ||

--- a/src/main/resources/lib/utils/content-utils.ts
+++ b/src/main/resources/lib/utils/content-utils.ts
@@ -2,6 +2,7 @@ import * as contextLib from '/lib/xp/context';
 import { Content } from '/lib/xp/content';
 import { RepoNode } from '/lib/xp/node';
 import { ContentDescriptor, MediaDescriptor } from '../../types/content-types/content-config';
+import { isPrepublished } from '../scheduling/scheduled-publish';
 import { logger } from './logging';
 import { COMPONENT_APP_KEY } from '../constants';
 
@@ -42,4 +43,8 @@ export const getContentLocaleRedirectTarget = (content: Content) => {
 
 export const isContentNoIndex = (content: Content<any>) => {
     return !!content.data?.noindex;
+};
+
+export const isContentPrepublished = (content: Content<any>) => {
+    return isPrepublished(content?.publish?.from);
 };


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Det så ut til at innhold som er forhåndspublisert fortsatt vises i søk. Her er forslag til løsning som sjekker på at innhold ikke er prePublished før det slipper igjennom til søkeresultat.

Mulig den ekstra gangen innom isContentPrepublished er litt redundant, men jeg tenkte det best å følge eksisterende arkitektur for filtrering av ugyldig innhold på samme måte som sjekk av preview etc.

## Testing
Testet i dev. Greier ikke lenger å gjenskape feilen.
