### PR TITLE
Hopper over components som inneholder '/topPageContent' ved bygg av n…

### DIFF
--- a/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/page-navigation-menu.ts
+++ b/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/page-navigation-menu.ts
@@ -105,6 +105,9 @@ const getComponentAnchorLink = (
     component: NodeComponent,
     repo: RepoConnection
 ): AnchorLink | null => {
+    if (component.path.includes('/topPageContent')) {
+        return null;
+    }
     if (component.type === 'layout') {
         return getLayoutAnchorLink(component.layout);
     }


### PR DESCRIPTION
## Oppsummering av hva som er gjort
regionen topPageContent er ikke lenger i bruk for produktsider. Dersom det ved et uhell ligger igjen komponenter her så er ikke disse synlige i frontend.

Vi skal på sikt rydde unna dette i objektene, men i denne omgang må vi hindre funksjonen som bygger internnavigasjonen i å ta med komponenter som ikke vil være synlige frontend.

## Testing
Testes i dev