### PR TITLE
Legger inn link som egen field-set for å fjerne påkrevetregel

### DIFF
--- a/.xp-codegen/site/parts/frontpage-current-topics/index.d.ts
+++ b/.xp-codegen/site/parts/frontpage-current-topics/index.d.ts
@@ -21,7 +21,7 @@ export type FrontpageCurrentTopics = {
   sortByPublishDate: boolean;
 
 
-  link:
+  link?:
     | {
         /**
          * Selected

--- a/src/main/resources/site/parts/frontpage-current-topics/frontpage-current-topics.xml
+++ b/src/main/resources/site/parts/frontpage-current-topics/frontpage-current-topics.xml
@@ -31,7 +31,27 @@
         <field-set>
             <label>Lenke til flere saker</label>
             <items>
-                <mixin name="link"/>
+                <option-set name="link">
+                    <occurrences minimum="0" maximum="1"/>
+                    <expanded>true</expanded>
+                    <options minimum="1" maximum="1">
+                        <option name="internal">
+                            <label>Intern lenke</label>
+                            <help-text>Lenke til internt innhold</help-text>
+                            <default>true</default>
+                            <items>
+                                <mixin name="link-internal" />
+                            </items>
+                        </option>
+                        <option name="external">
+                            <label>Ekstern lenke</label>
+                            <help-text>Lenke til innhold utenfor CMS'et</help-text>
+                            <items>
+                                <mixin name="link-external" />
+                            </items>
+                        </option>
+                    </options>
+                </option-set>
             </items>
         </field-set>
     </form>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Det er behov for å kunne legge inn aktuelle saker på underforside (samarbeidspartner) uten å legge lenke til "Flere saker". Derfor må denne løftes ut av mixin og gjøres optional.

## Testing
Testet i dev

