### PR TITLE
Fikser feil med hjelpemiddelsentral

### DIFF
--- a/src/main/resources/lib/guillotine/queries/run-sitecontent-query.ts
+++ b/src/main/resources/lib/guillotine/queries/run-sitecontent-query.ts
@@ -52,7 +52,10 @@ export const runSitecontentGuillotineQuery = (
     }
 
     // Certain pages need extra queries for resolving.
-    if (baseContent.type === 'no.nav.navno:office-page') {
+    if (
+        baseContent.type === 'no.nav.navno:office-page' &&
+        baseContent.data?.officeNorgData.data.type === 'LOKAL'
+    ) {
         return buildOfficeBranchPageWithEditorialContent(contentQueryResult);
     }
 


### PR DESCRIPTION
## Oppsummering av hva som er gjort
En feil gjorde at kontorsider for hjelpemiddelsentral forsøker å resolve office-editorial-innhold på samme måte som for lokalkontorsider. Det gjorde at fragmenter feilet. Innholdet var fortsatt synlig frontend pga Redis, så det var ingenting som traff brukere.

## Testing
Testet i dev