### PR TITLE
Re importerer enkelte hms

### DIFF
--- a/src/main/resources/lib/office-pages/_legacy-office-information/legacy-office-update.ts
+++ b/src/main/resources/lib/office-pages/_legacy-office-information/legacy-office-update.ts
@@ -93,11 +93,10 @@ const updateOfficeInfo = (officeInformationUpdated: OfficeInformation[]) => {
         officesInNorg[enhet.enhetId] = true;
 
         const updatedName = commonLib.sanitize(enhet.navn);
+
         // Temporary check to only import lagging HMS that hasn't been
         // transferred to new layout
-
         if (enhet.type === 'HMS' && !remainingHMSToImport.has(updatedName)) {
-            log.info(`Skipping hmsimport ${updatedName}`);
             return;
         }
 
@@ -302,7 +301,7 @@ export const startOfficeInfoPeriodicUpdateSchedule = () => {
         jobDescription: 'Updates legacy office information from norg2 every hour',
         jobSchedule: {
             type: 'CRON',
-            value: '*/5 * * * *',
+            value: '*/10 * * * *',
             timeZone: 'GMT+2:00',
         },
         taskDescriptor: officeInfoUpdateTaskDescriptor,

--- a/src/main/resources/lib/office-pages/_legacy-office-information/legacy-office-update.ts
+++ b/src/main/resources/lib/office-pages/_legacy-office-information/legacy-office-update.ts
@@ -302,7 +302,7 @@ export const startOfficeInfoPeriodicUpdateSchedule = () => {
         jobDescription: 'Updates legacy office information from norg2 every hour',
         jobSchedule: {
             type: 'CRON',
-            value: '*/20 * * * *',
+            value: '*/5 * * * *',
             timeZone: 'GMT+2:00',
         },
         taskDescriptor: officeInfoUpdateTaskDescriptor,

--- a/src/main/resources/lib/office-pages/_legacy-office-information/legacy-office-update.ts
+++ b/src/main/resources/lib/office-pages/_legacy-office-information/legacy-office-update.ts
@@ -22,9 +22,23 @@ const fiveMinutes = 5 * 60 * 1000;
 
 const enhetTypesToImport: ReadonlySet<string> = new Set([
     'ALS',
+    'HMS',
     'KONTROLL',
     'OKONOMI',
     'OPPFUTLAND',
+]);
+
+const remainingHMSToImport: ReadonlySet<string> = new Set([
+    'nav-hjelpemiddelsentral-rogaland',
+    'nav-hjelpemiddelsentral-more-og-romsdal',
+    'nav-hjelpemiddelsentral-nordland',
+    'nav-hjelpemiddelsentral-trondelag',
+    'nav-hjelpemiddelsentral-ost-viken',
+    'nav-hjelpemiddelsentral-vest-viken',
+    'nav-hjelpemiddelsentral-troms-og-finnmark',
+    'nav-hjelpemiddelsentral-vestland-forde',
+    'nav-hjelpemiddelsentral-vestland-bergen',
+    'styringsenheten-for-nav-hjelpemidler-og-tilrettelegging',
 ]);
 
 // If non-office information content already exists on the path for an office, delete it
@@ -79,6 +93,14 @@ const updateOfficeInfo = (officeInformationUpdated: OfficeInformation[]) => {
         officesInNorg[enhet.enhetId] = true;
 
         const updatedName = commonLib.sanitize(enhet.navn);
+        // Temporary check to only import lagging HMS that hasn't been
+        // transferred to new layout
+
+        if (enhet.type === 'HMS' && !remainingHMSToImport.has(updatedName)) {
+            log.info(`Skipping hmsimport ${updatedName}`);
+            return;
+        }
+
         deleteIfContentExists(updatedName);
 
         const existingOffice = existingOffices.find(
@@ -280,7 +302,7 @@ export const startOfficeInfoPeriodicUpdateSchedule = () => {
         jobDescription: 'Updates legacy office information from norg2 every hour',
         jobSchedule: {
             type: 'CRON',
-            value: '15 * * * *',
+            value: '*/20 * * * *',
             timeZone: 'GMT+2:00',
         },
         taskDescriptor: officeInfoUpdateTaskDescriptor,


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Enkelte hjelpemiddelsentralsider må fortsatt eksistere som legacy-versjon. Setter opp en unntaksliste slik at kun disse blir importert. De er på vei over i nye maler, så vi må bare fjerne de fortløpende når vi får beskjed fra HMS.

## Testing
Testet i Q6