### PR TITLE
Fix richtext callback

### DIFF
--- a/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/richtext.ts
+++ b/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/richtext.ts
@@ -45,7 +45,9 @@ const resolvePublicPathsInLinks = (processedHtml: string, links?: Link[]) => {
         const internalPath = stripPathPrefix(targetContent._path);
         const publicPath = getPublicPath(targetContent, localeFromContext);
 
-        return html.replace(new RegExp(`href="${internalPath}`, 'g'), `href="${publicPath}`);
+        return html.replace(new RegExp(`href="${internalPath}(["?#])`, 'g'), (match) =>
+            match.replace(internalPath, publicPath)
+        );
     }, processedHtml);
 };
 

--- a/test/unit-tests/tests/lib/guillotine/schema/schema-creation-callbacks/richtext.test.ts
+++ b/test/unit-tests/tests/lib/guillotine/schema/schema-creation-callbacks/richtext.test.ts
@@ -83,7 +83,7 @@ describe('Guillotine richtext resolver', () => {
         );
     });
 
-    test('Should resolve link to custom path including anchor', () => {
+    test('Should resolve link to custom path with anchor', () => {
         const params = createParams();
         richTextCallback({} as any, params);
 
@@ -102,6 +102,28 @@ describe('Guillotine richtext resolver', () => {
 
         expect(result).toBe(
             `<p>Hello world! <a href="${contentWithCustomPath.data.customPath}#my-anchor">Link to content with custom path with anchor</a></p>`
+        );
+    });
+
+    test('Should resolve link to custom path with parameter', () => {
+        const params = createParams();
+        richTextCallback({} as any, params);
+
+        const result = params.fields.processedHtml.resolve!({
+            source: {
+                processedHtml: `<p>Hello world! <a href="${contentWithCustomPath._path}?foo=bar">Link to content with custom path with anchor</a></p>`,
+                links: [
+                    {
+                        contentId: contentWithCustomPath._id,
+                    },
+                ],
+            },
+            args: {},
+            context: {},
+        });
+
+        expect(result).toBe(
+            `<p>Hello world! <a href="${contentWithCustomPath.data.customPath}?foo=bar">Link to content with custom path with anchor</a></p>`
         );
     });
 

--- a/test/unit-tests/tests/lib/guillotine/schema/schema-creation-callbacks/richtext.test.ts
+++ b/test/unit-tests/tests/lib/guillotine/schema/schema-creation-callbacks/richtext.test.ts
@@ -1,0 +1,132 @@
+import { richTextCallback } from '@navno-app/lib/guillotine/schema/schema-creation-callbacks/richtext';
+import { CreateObjectTypeParams } from '/lib/graphql';
+import { xpMocks } from '../../../../../.mocks/xp-mocks';
+
+const { libContentMock } = xpMocks;
+
+const createParams = (): CreateObjectTypeParams => ({
+    fields: {
+        processedHtml: {
+            type: { name: 'String' },
+        },
+    },
+    name: 'RichText',
+});
+
+const contentWithoutCustomPath = libContentMock.create({
+    contentType: 'no.nav.navno:dynamic-page',
+    data: {},
+    displayName: 'Content without custom path',
+    parentPath: '/',
+    name: 'content-without-custom-path',
+});
+
+const contentWithCustomPath = libContentMock.create({
+    contentType: 'no.nav.navno:dynamic-page',
+    data: { customPath: '/my-custom-path' },
+    displayName: 'Content with custom path',
+    parentPath: '/',
+    name: 'content-with-custom-path',
+});
+
+const childContentWithCustomPath = libContentMock.create({
+    contentType: 'no.nav.navno:dynamic-page',
+    data: { customPath: '/my-other-custom-path' },
+    displayName: 'Another content with custom path',
+    parentPath: '/content-with-custom-path',
+    name: 'content-with-another-custom-path',
+});
+
+describe('Guillotine richtext resolver', () => {
+    test('Should preserve link to internal path if no custom path set', () => {
+        const params = createParams();
+        richTextCallback({} as any, params);
+
+        const htmlInput = `<p>Hello world! <a href="${contentWithoutCustomPath._path}">Link to content without custom path</a></p>`;
+
+        const processedHtml = params.fields.processedHtml.resolve!({
+            source: {
+                processedHtml: htmlInput,
+                links: [
+                    {
+                        contentId: contentWithoutCustomPath._id,
+                    },
+                ],
+            },
+            args: {},
+            context: {},
+        });
+
+        expect(processedHtml).toBe(htmlInput);
+    });
+
+    test('Should resolve link to custom path', () => {
+        const params = createParams();
+        richTextCallback({} as any, params);
+
+        const result = params.fields.processedHtml.resolve!({
+            source: {
+                processedHtml: `<p>Hello world! <a href="${contentWithCustomPath._path}">Link to content with custom path</a></p>`,
+                links: [
+                    {
+                        contentId: contentWithCustomPath._id,
+                        linkRef: '1234',
+                    },
+                ],
+            },
+            args: {},
+            context: {},
+        });
+
+        expect(result).toBe(
+            `<p>Hello world! <a href="${contentWithCustomPath.data.customPath}">Link to content with custom path</a></p>`
+        );
+    });
+
+    test('Should resolve link to custom path including anchor', () => {
+        const params = createParams();
+        richTextCallback({} as any, params);
+
+        const result = params.fields.processedHtml.resolve!({
+            source: {
+                processedHtml: `<p>Hello world! <a href="${contentWithCustomPath._path}#my-anchor">Link to content with custom path with anchor</a></p>`,
+                links: [
+                    {
+                        contentId: contentWithCustomPath._id,
+                    },
+                ],
+            },
+            args: {},
+            context: {},
+        });
+
+        expect(result).toBe(
+            `<p>Hello world! <a href="${contentWithCustomPath.data.customPath}#my-anchor">Link to content with custom path with anchor</a></p>`
+        );
+    });
+
+    test('Should resolve multiple links', () => {
+        const params = createParams();
+        richTextCallback({} as any, params);
+
+        const result = params.fields.processedHtml.resolve!({
+            source: {
+                processedHtml: `<p>Hello world! <a href="${contentWithCustomPath._path}">Link to parent content</a><a href="${childContentWithCustomPath._path}">Link to child content</a></p>`,
+                links: [
+                    {
+                        contentId: contentWithCustomPath._id,
+                    },
+                    {
+                        contentId: childContentWithCustomPath._id,
+                    },
+                ],
+            },
+            args: {},
+            context: {},
+        });
+
+        expect(result).toBe(
+            `<p>Hello world! <a href="${contentWithCustomPath.data.customPath}">Link to parent content</a><a href="${childContentWithCustomPath.data.customPath}">Link to child content</a></p>`
+        );
+    });
+});


### PR DESCRIPTION
Fikser en bug som kan oppstå i publicPath resolveren dersom en htmlarea input innholder flere lenker til content-referanser, hvor noen contents er descendants av andre.

Eks:
```
<a href="/path/to/content">foo</a>
<a href="/path/to/content/child">bar</a>
```

Dersom innholdet med intern _path `/path/to/content` har customPath `/my-path`, så vil med dagens løsning den andre lenken resolves til `/my-path/child` 😅 