### PR TITLE
Fjerner Nordland fra import av gamle hjelpemiddelsentraler

### DIFF
--- a/src/main/resources/lib/office-pages/_legacy-office-information/legacy-office-update.ts
+++ b/src/main/resources/lib/office-pages/_legacy-office-information/legacy-office-update.ts
@@ -29,7 +29,6 @@ const enhetNrToImport: ReadonlySet<string> = new Set([
     '4712', // [HMS] Vestland-Bergen
     '4714', // [HMS] Vestland-Førde
     '4716', // [HMS] Trøndalag
-    '4718', // [HMS] Nordland
 ]);
 
 const shouldImportOffice = (enhet: OfficeInformation['enhet']) => {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Fjerner Nordland fra hjelpemiddelsentral legacy import.

## Testing
Testes i dev
