### PR TITLE
Inkluderer alt innhold som er eller har vært publisert i services for eksternt arkiv

### DIFF
--- a/src/main/resources/lib/external-archive/content-tree-archive.ts
+++ b/src/main/resources/lib/external-archive/content-tree-archive.ts
@@ -1,0 +1,48 @@
+import { RepoConnection } from '/lib/xp/node';
+import { getParentPath } from '../paths/path-utils';
+import { logger } from '../utils/logging';
+import { Content } from '/lib/xp/content';
+
+export const getContentFromArchive = (path: string, repo: RepoConnection) => {
+    const parentPath = getParentPath(path);
+    const name = path.split('/').pop();
+
+    const archivedResult = repo.query({
+        count: 1,
+        sort: {
+            field: '_ts',
+            direction: 'DESC',
+        },
+        filters: {
+            boolean: {
+                must: [
+                    {
+                        hasValue: {
+                            field: 'originalParentPath',
+                            values: [parentPath],
+                        },
+                    },
+                    {
+                        hasValue: {
+                            field: 'originalName',
+                            values: [name],
+                        },
+                    },
+                ],
+            },
+        },
+    });
+
+    if (archivedResult.total === 0) {
+        return null;
+    }
+
+    if (archivedResult.total > 1) {
+        logger.error(`Found ${archivedResult.total} hits in the archive for ${path}`);
+    }
+
+    const content = repo.get<Content>(archivedResult.hits[0].id);
+    if (!content) {
+        return null;
+    }
+};

--- a/src/main/resources/lib/external-archive/content-tree.ts
+++ b/src/main/resources/lib/external-archive/content-tree.ts
@@ -1,0 +1,104 @@
+import { ContentDescriptor } from '../../types/content-types/content-config';
+import { NAVNO_NODE_ROOT_PATH } from '../constants';
+import { Content } from '/lib/xp/content';
+import { RepoConnection } from '/lib/xp/node';
+import { NON_LOCALIZED_QUERY_FILTER } from '../localization/layers-repo-utils/localization-state-filters';
+import { stripPathPrefix } from '../paths/path-utils';
+import { isContentLocalized } from '../localization/locale-utils';
+import { logger } from '../utils/logging';
+import { forceArray } from '../utils/array-utils';
+import { getRepoConnection } from '../utils/repo-utils';
+import { getLayersData } from '../localization/layers-data';
+
+type ContentTreeEntry = {
+    id: string;
+    path: string;
+    name: string;
+    displayName: string;
+    type: ContentDescriptor;
+    numChildren: number;
+    isLocalized: boolean;
+    hasLocalizedDescendants: boolean;
+};
+
+// TODO: implement pagination with smaller chunks
+const MAX_CHILDREN_COUNT = 1000;
+
+const getFullNodePath = (path: string) => `${NAVNO_NODE_ROOT_PATH}${path.replace(/\/$/, '')}`;
+
+const hasLocalizedDescendants = (content: Content, repo: RepoConnection) => {
+    const result = repo.query({
+        count: 0,
+        query: {
+            like: {
+                field: '_path',
+                value: `${content._path}/*`,
+            },
+        },
+        filters: {
+            boolean: {
+                mustNot: NON_LOCALIZED_QUERY_FILTER,
+            },
+        },
+    });
+
+    return result.total > 0;
+};
+
+const transformToContentTreeEntry = (content: Content, repo: RepoConnection): ContentTreeEntry => {
+    const childrenResult = repo.findChildren({
+        parentKey: content._id,
+        countOnly: true,
+    });
+
+    return {
+        id: content._id,
+        path: stripPathPrefix(content._path),
+        name: content._name,
+        displayName: content.displayName,
+        type: content.type,
+        numChildren: childrenResult.total,
+        isLocalized: isContentLocalized(content),
+        hasLocalizedDescendants: hasLocalizedDescendants(content, repo),
+    };
+};
+
+const getContentTreeChildren = (
+    parentContent: Content,
+    repo: RepoConnection
+): ContentTreeEntry[] => {
+    const findChildrenResult = repo.findChildren({
+        parentKey: parentContent._id,
+        count: MAX_CHILDREN_COUNT,
+    });
+
+    if (findChildrenResult.total > MAX_CHILDREN_COUNT) {
+        logger.error(
+            `Found ${findChildrenResult.total} children count exceeds the maximum ${MAX_CHILDREN_COUNT}!`
+        );
+    }
+
+    const ids = findChildrenResult.hits.map((hit) => hit.id);
+
+    const childContents = repo.get<Content>(ids);
+
+    return forceArray(childContents).map((content) => transformToContentTreeEntry(content, repo));
+};
+
+export const getContentTreeData = (path: string, locale: string) => {
+    const repo = getRepoConnection({
+        repoId: getLayersData().localeToRepoIdMap[locale],
+        branch: 'draft',
+        asAdmin: true,
+    });
+
+    const content = repo.get<Content>(getFullNodePath(path));
+    if (!content) {
+        return null;
+    }
+
+    return {
+        current: transformToContentTreeEntry(content, repo),
+        children: getContentTreeChildren(content, repo),
+    };
+};

--- a/src/main/resources/lib/external-archive/content-tree.ts
+++ b/src/main/resources/lib/external-archive/content-tree.ts
@@ -67,6 +67,9 @@ const getContentChildren = (parentContent: Content, repo: RepoConnection): Conte
     const { hits, total } = repo.findChildren({
         parentKey: parentContent._id,
         count: MAX_CHILDREN_COUNT,
+        // According to docs it should inherit the childOrder automatically if this is not set,
+        // but that does not seem to be the case, so we have to set it ourselves
+        childOrder: parentContent.childOrder,
     });
 
     if (total > MAX_CHILDREN_COUNT) {

--- a/src/main/resources/lib/external-archive/content-tree.ts
+++ b/src/main/resources/lib/external-archive/content-tree.ts
@@ -3,12 +3,12 @@ import { NAVNO_NODE_ROOT_PATH } from '../constants';
 import { Content } from '/lib/xp/content';
 import { RepoConnection } from '/lib/xp/node';
 import { NON_LOCALIZED_QUERY_FILTER } from '../localization/layers-repo-utils/localization-state-filters';
-import { stripPathPrefix } from '../paths/path-utils';
+import { stripPathPrefix, stripTrailingSlash } from '../paths/path-utils';
 import { isContentLocalized } from '../localization/locale-utils';
 import { logger } from '../utils/logging';
-import { forceArray } from '../utils/array-utils';
 import { getRepoConnection } from '../utils/repo-utils';
 import { getLayersData } from '../localization/layers-data';
+import { getLastPublishedContentVersion } from './last-published-content';
 
 type ContentTreeEntry = {
     id: string;
@@ -24,7 +24,7 @@ type ContentTreeEntry = {
 // TODO: implement pagination with smaller chunks
 const MAX_CHILDREN_COUNT = 1000;
 
-const getFullNodePath = (path: string) => `${NAVNO_NODE_ROOT_PATH}${path.replace(/\/$/, '')}`;
+const getFullNodePath = (path: string) => `${NAVNO_NODE_ROOT_PATH}${stripTrailingSlash(path)}`;
 
 const hasLocalizedDescendants = (content: Content, repo: RepoConnection) => {
     const result = repo.query({
@@ -63,42 +63,53 @@ const transformToContentTreeEntry = (content: Content, repo: RepoConnection): Co
     };
 };
 
-const getContentTreeChildren = (
-    parentContent: Content,
-    repo: RepoConnection
-): ContentTreeEntry[] => {
-    const findChildrenResult = repo.findChildren({
+const getContentChildren = (parentContent: Content, repo: RepoConnection): ContentTreeEntry[] => {
+    const { hits, total } = repo.findChildren({
         parentKey: parentContent._id,
         count: MAX_CHILDREN_COUNT,
     });
 
-    if (findChildrenResult.total > MAX_CHILDREN_COUNT) {
-        logger.error(
-            `Found ${findChildrenResult.total} children count exceeds the maximum ${MAX_CHILDREN_COUNT}!`
-        );
+    if (total > MAX_CHILDREN_COUNT) {
+        logger.error(`Found ${total} children count exceeds the maximum ${MAX_CHILDREN_COUNT}!`);
     }
 
-    const ids = findChildrenResult.hits.map((hit) => hit.id);
+    const childContents = hits.reduce<ContentTreeEntry[]>((acc, { id }) => {
+        const content = getLastPublishedContentVersion(id, repo);
+        if (content) {
+            acc.push(transformToContentTreeEntry(content, repo));
+        }
 
-    const childContents = repo.get<Content>(ids);
+        return acc;
+    }, []);
 
-    return forceArray(childContents).map((content) => transformToContentTreeEntry(content, repo));
+    return childContents;
 };
 
-export const getContentTreeData = (path: string, locale: string) => {
+export const buildExternalArchiveContentTreeLevel = (
+    path: string,
+    locale: string,
+    fromXpArchive: boolean
+) => {
     const repo = getRepoConnection({
         repoId: getLayersData().localeToRepoIdMap[locale],
         branch: 'draft',
         asAdmin: true,
     });
 
-    const content = repo.get<Content>(getFullNodePath(path));
+    // TODO: implement this somehow :D
+    if (fromXpArchive) {
+        return null;
+    }
+
+    const nodePath = getFullNodePath(path);
+
+    const content = getLastPublishedContentVersion(nodePath, repo);
     if (!content) {
         return null;
     }
 
     return {
         current: transformToContentTreeEntry(content, repo),
-        children: getContentTreeChildren(content, repo),
+        children: getContentChildren(content, repo),
     };
 };

--- a/src/main/resources/lib/external-archive/last-published-content.ts
+++ b/src/main/resources/lib/external-archive/last-published-content.ts
@@ -1,0 +1,29 @@
+import { Content } from '/lib/xp/content';
+import { transformRepoContentNode } from '../utils/content-utils';
+import { RepoConnection } from '/lib/xp/node';
+
+export const getLastPublishedContentVersion = (
+    contentKey: string,
+    repo: RepoConnection
+): Content | null => {
+    const versions = repo.findVersions({ key: contentKey, count: 1000 });
+
+    if (versions.total === 0) {
+        return null;
+    }
+
+    const lastPublishedVersion = versions.hits.find((version) => !!version.commitId);
+    if (!lastPublishedVersion) {
+        return null;
+    }
+
+    const contentNode = repo.get<Content>({
+        key: lastPublishedVersion.nodeId,
+        versionId: lastPublishedVersion.versionId,
+    });
+    if (!contentNode) {
+        return null;
+    }
+
+    return transformRepoContentNode(contentNode);
+};

--- a/src/main/resources/lib/paths/path-utils.ts
+++ b/src/main/resources/lib/paths/path-utils.ts
@@ -24,6 +24,8 @@ export const stripRedirectsPathPrefix = (path: string) => path.replace(redirects
 
 export const stripLeadingAndTrailingSlash = (path: string) => path.replace(/(^\/)|(\/$)/, '');
 
+export const stripTrailingSlash = (path: string) => path.replace(/\/$/, '');
+
 export const isWellFormedContentRef = (contentRef: string) => {
     try {
         // This will throw if the key is malformed (invalid characters etc)

--- a/src/main/resources/lib/utils/content-utils.ts
+++ b/src/main/resources/lib/utils/content-utils.ts
@@ -56,3 +56,17 @@ export const isContentAwaitingPrepublish = (
 // If the content ref is a path, ensure it has the /content prefix
 export const getContentNodeKey = (contentRef: string) =>
     contentRef.replace(/^\/www.nav.no/, '/content/www.nav.no');
+
+export const transformRepoContentNode = (node: RepoNode<Content>): Content => {
+    const {
+        _childOrder,
+        _indexConfig,
+        _inheritsPermissions,
+        _permissions,
+        _state,
+        _nodeType,
+        ...content
+    } = node;
+
+    return content;
+};

--- a/src/main/resources/lib/utils/content-utils.ts
+++ b/src/main/resources/lib/utils/content-utils.ts
@@ -68,5 +68,5 @@ export const transformRepoContentNode = (node: RepoNode<Content>): Content => {
         ...content
     } = node;
 
-    return content;
+    return { ...content, childOrder: _childOrder };
 };

--- a/src/main/resources/services/dataQuery/dataQuery.ts
+++ b/src/main/resources/services/dataQuery/dataQuery.ts
@@ -17,6 +17,7 @@ import { runInLocaleContext } from '../../lib/localization/locale-context';
 import { getPublicPath } from '../../lib/paths/public-path';
 import { parseJsonToArray } from '../../lib/utils/array-utils';
 import { getLayersMultiConnection } from '../../lib/localization/layers-repo-utils/layers-repo-connection';
+import { transformRepoContentNode } from '../../lib/utils/content-utils';
 
 type Branch = 'published' | 'unpublished' | 'archived';
 
@@ -101,20 +102,6 @@ const getNodeHitsFromQuery = ({ query, branch, types, requestId }: RunQueryParam
     return result;
 };
 
-const transformRepoNode = (node: RepoNode<Content>): Content => {
-    const {
-        _childOrder,
-        _indexConfig,
-        _inheritsPermissions,
-        _permissions,
-        _state,
-        _nodeType,
-        ...content
-    } = node;
-
-    return content;
-};
-
 const runArchiveQuery = (nodeHitsBuckets: RepoIdNodeIdBuckets) => {
     const { repoIdToLocaleMap } = getLayersData();
 
@@ -133,8 +120,8 @@ const runArchiveQuery = (nodeHitsBuckets: RepoIdNodeIdBuckets) => {
             }
 
             const hits = Array.isArray(result)
-                ? result.map(transformRepoNode)
-                : [transformRepoNode(result)];
+                ? result.map(transformRepoContentNode)
+                : [transformRepoContentNode(result)];
 
             const hitsWithRepoIds = hits.map((content) => {
                 return {

--- a/src/main/resources/services/externalArchive/contentTree/contentTree.ts
+++ b/src/main/resources/services/externalArchive/contentTree/contentTree.ts
@@ -1,10 +1,11 @@
 import { validateServiceSecretHeader } from '../../../lib/utils/auth-utils';
 import { isValidLocale } from '../../../lib/localization/layers-data';
-import { getContentTreeData } from '../../../lib/external-archive/content-tree';
+import { buildExternalArchiveContentTreeLevel } from '../../../lib/external-archive/content-tree';
 
 type Params = Partial<{
     path: string;
     locale: string;
+    fromArchive?: 'true';
 }>;
 
 export const externalArchiveContentTreeGet = (req: XP.Request) => {
@@ -18,7 +19,7 @@ export const externalArchiveContentTreeGet = (req: XP.Request) => {
         };
     }
 
-    const { path, locale } = req.params as Params;
+    const { path, locale, fromArchive } = req.params as Params;
 
     if (!path) {
         return {
@@ -34,13 +35,17 @@ export const externalArchiveContentTreeGet = (req: XP.Request) => {
         return {
             status: 400,
             body: {
-                message: `Locale ${locale} is not valid`,
+                message: 'Locale not specified or invalid',
             },
             contentType: 'application/json',
         };
     }
 
-    const contentTreeData = getContentTreeData(path, locale);
+    const contentTreeData = buildExternalArchiveContentTreeLevel(
+        path,
+        locale,
+        fromArchive === 'true'
+    );
 
     if (!contentTreeData) {
         return {

--- a/src/main/resources/services/externalArchive/contentTree/contentTree.ts
+++ b/src/main/resources/services/externalArchive/contentTree/contentTree.ts
@@ -1,87 +1,6 @@
-import { Content } from '/lib/xp/content';
-import { stripPathPrefix } from '../../../lib/paths/path-utils';
 import { validateServiceSecretHeader } from '../../../lib/utils/auth-utils';
-import { ContentDescriptor } from '../../../types/content-types/content-config';
-import { getLayersData, isValidLocale } from '../../../lib/localization/layers-data';
-import { getRepoConnection } from '../../../lib/utils/repo-utils';
-import { RepoConnection } from '/lib/xp/node';
-import { forceArray } from '../../../lib/utils/array-utils';
-import { logger } from '../../../lib/utils/logging';
-import { isContentLocalized } from '../../../lib/localization/locale-utils';
-import { NON_LOCALIZED_QUERY_FILTER } from '../../../lib/localization/layers-repo-utils/localization-state-filters';
-import { NAVNO_NODE_ROOT_PATH } from '../../../lib/constants';
-
-type ContentTreeEntry = {
-    id: string;
-    path: string;
-    name: string;
-    displayName: string;
-    type: ContentDescriptor;
-    numChildren: number;
-    isLocalized: boolean;
-    hasLocalizedDescendants: boolean;
-};
-
-// TODO: implement pagination with smaller chunks
-const MAX_CHILDREN_COUNT = 1000;
-
-const getFullNodePath = (path: string) => `${NAVNO_NODE_ROOT_PATH}${path.replace(/\/$/, '')}`;
-
-const hasLocalizedDescendants = (content: Content, repo: RepoConnection) => {
-    const result = repo.query({
-        count: 0,
-        query: {
-            like: {
-                field: '_path',
-                value: `${content._path}/*`,
-            },
-        },
-        filters: {
-            boolean: {
-                mustNot: NON_LOCALIZED_QUERY_FILTER,
-            },
-        },
-    });
-
-    return result.total > 0;
-};
-
-const transformToContentTreeEntry = (content: Content, repo: RepoConnection): ContentTreeEntry => {
-    const childrenResult = repo.findChildren({
-        parentKey: content._id,
-        countOnly: true,
-    });
-
-    return {
-        id: content._id,
-        path: stripPathPrefix(content._path),
-        name: content._name,
-        displayName: content.displayName,
-        type: content.type,
-        numChildren: childrenResult.total,
-        isLocalized: isContentLocalized(content),
-        hasLocalizedDescendants: hasLocalizedDescendants(content, repo),
-    };
-};
-
-const getContentTreeChildren = (path: string, repo: RepoConnection): ContentTreeEntry[] => {
-    const findChildrenResult = repo.findChildren({
-        parentKey: getFullNodePath(path),
-        count: MAX_CHILDREN_COUNT,
-    });
-
-    if (findChildrenResult.total > MAX_CHILDREN_COUNT) {
-        logger.error(
-            `Found ${findChildrenResult.total} children count exceeds the maximum ${MAX_CHILDREN_COUNT}!`
-        );
-    }
-
-    const ids = findChildrenResult.hits.map((hit) => hit.id);
-
-    const childContents = repo.get<Content>(ids);
-
-    return forceArray(childContents).map((content) => transformToContentTreeEntry(content, repo));
-};
+import { isValidLocale } from '../../../lib/localization/layers-data';
+import { getContentTreeData } from '../../../lib/external-archive/content-tree';
 
 type Params = Partial<{
     path: string;
@@ -121,19 +40,13 @@ export const externalArchiveContentTreeGet = (req: XP.Request) => {
         };
     }
 
-    const repo = getRepoConnection({
-        repoId: getLayersData().localeToRepoIdMap[locale],
-        branch: 'draft',
-        asAdmin: true,
-    });
+    const contentTreeData = getContentTreeData(path, locale);
 
-    const parentContent = repo.get<Content>(getFullNodePath(path));
-
-    if (!parentContent) {
+    if (!contentTreeData) {
         return {
             status: 404,
             body: {
-                message: `Not found: ${path}`,
+                message: `Not found: ${path} in ${locale}`,
             },
             contentType: 'application/json',
         };
@@ -141,10 +54,7 @@ export const externalArchiveContentTreeGet = (req: XP.Request) => {
 
     return {
         status: 200,
-        body: {
-            current: transformToContentTreeEntry(parentContent, repo),
-            children: getContentTreeChildren(path, repo),
-        },
+        body: contentTreeData,
         contentType: 'application/json',
     };
 };


### PR DESCRIPTION
Fikser også sorteringsrekkefølge på contentTree response