### PR TITLE
Validerer målgruppe-segment i kort-url'er

### DIFF
--- a/src/main/resources/lib/controllers/form-intermediate-step-controller.ts
+++ b/src/main/resources/lib/controllers/form-intermediate-step-controller.ts
@@ -6,7 +6,7 @@ import { getRepoConnection } from '../repos/repo-utils';
 import {
     formIntermediateStepGenerateCustomPath,
     formIntermediateStepValidateCustomPath,
-} from '../paths/custom-paths/custom-path-special-types';
+} from '../paths/custom-paths/custom-path-content-validators';
 
 const insertCustomPath = (req: XP.Request) => {
     const content = portalLib.getContent();

--- a/src/main/resources/lib/paths/custom-paths/custom-path-content-validators.ts
+++ b/src/main/resources/lib/paths/custom-paths/custom-path-content-validators.ts
@@ -14,7 +14,7 @@ const audienceSegmentMap: Record<string, string> = {
 
 type Audience = AudienceMixin['audience']['_selected'];
 
-export const getSingleAudienceFromContent = (content: Content<any>): Audience | null => {
+const getSingleAudienceFromContent = (content: Content<any>): Audience | null => {
     const audience = content.data?.audience as
         | ArrayOrSingle<Audience>
         | AudienceMixin['audience']

--- a/src/main/resources/services/customPathSelector/customPathSelector.ts
+++ b/src/main/resources/services/customPathSelector/customPathSelector.ts
@@ -137,13 +137,11 @@ const getResult = ({
                 `Eksempel på gyldig url: ${examplePath}`
             );
         }
-    } else {
-        if (!validateCustomPathForContentAudience(content, suggestedPath)) {
-            return generateErrorHit(
-                `Feil: "${suggestedPath}" er ikke en gyldig url for denne målgruppen`,
-                `Url må starte med "${getExpectedCustomPathAudiencePrefix(content)}"`
-            );
-        }
+    } else if (!validateCustomPathForContentAudience(content, suggestedPath)) {
+        return generateErrorHit(
+            `Feil: "${suggestedPath}" er ikke en gyldig url for denne målgruppen`,
+            `Url må starte med "${getExpectedCustomPathAudiencePrefix(content)}"`
+        );
     }
 
     return {

--- a/src/main/resources/site/content-types/form-intermediate-step/form-intermediate-step.xml
+++ b/src/main/resources/site/content-types/form-intermediate-step/form-intermediate-step.xml
@@ -25,7 +25,6 @@
                     <occurrences minimum="1" maximum="1"/>
                     <config>
                         <service>customPathSelector</service>
-                        <param value="type">formIntermediateStep</param>
                     </config>
                 </input>
             </items>


### PR DESCRIPTION
Sider med målgruppe arbeidsgiver må starte med /arbeidsgiver
Sider med målgruppe samarbeidspartner må starte med /samarbeidspartner