### PR TITLE
Fjerner artikler fra artikkelliste uten å markere den som endret

### DIFF
--- a/src/main/resources/lib/contentlists/remove-unpublished.ts
+++ b/src/main/resources/lib/contentlists/remove-unpublished.ts
@@ -1,4 +1,5 @@
 import * as contentLib from '/lib/xp/content';
+import * as contextLib from '/lib/xp/context';
 import { Content } from '/lib/xp/content';
 import * as eventLib from '/lib/xp/event';
 import { runInContext } from '../context/run-in-context';
@@ -8,6 +9,7 @@ import { forceArray } from '../utils/array-utils';
 import { CONTENT_REPO_PREFIX } from '../constants';
 import { NavNoDescriptor } from '../../types/common';
 import { isMainDatanode } from '../cluster-utils/main-datanode';
+import { getRepoConnection, isDraftAndMasterSameVersion } from '../repos/repo-utils';
 
 type ContentTypesWithContentLists = NavNoDescriptor<'content-list'> | NavNoDescriptor<'page-list'>;
 
@@ -47,14 +49,27 @@ const removeUnpublishedFromContentList = (
     let numRemoved = 0;
 
     try {
-        runInContext({ branch: 'draft', asAdmin: true }, () =>
-            contentLib.modify<ContentTypesWithContentLists>({
+        runInContext({ branch: 'draft', asAdmin: true }, () => {
+            const context = contextLib.get();
+            const repoConnection = getRepoConnection({
+                branch: 'draft',
+                repoId: context.repository,
+            });
+
+            log.info(`Start pruning content list ${contentList._id}`);
+
+            const shouldPushChanges = isDraftAndMasterSameVersion(
+                contentList._id,
+                context.repository
+            );
+
+            repoConnection.modify<Content>({
                 key: contentList._id,
-                requireValid: false,
                 editor: (content) => {
                     const sectionContents = forceArray(content.data?.sectionContents);
 
                     if (sectionContents.length === 0) {
+                        log.info('sectionContents is empty, skipping');
                         return content;
                     }
 
@@ -73,8 +88,21 @@ const removeUnpublishedFromContentList = (
 
                     return content;
                 },
-            })
-        );
+            });
+
+            if (shouldPushChanges) {
+                repoConnection.commit({ keys: contentList._id });
+                repoConnection.push({
+                    key: contentList._id,
+                    target: 'master',
+                    includeChildren: false,
+                });
+            } else {
+                log.info(
+                    'Removed unpublished content from content list, but draft and master are out of sync, so not pushing changes.'
+                );
+            }
+        });
     } catch (e) {
         logger.error(`Error while modifying ${contentList._id} - ${e}`);
         return 0;


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Artikler som er utløpt eller avpublisert blir fjernet fra artikkellister, men disse blir (nylig?) blitt satt som _endret_ etter at scriptet har gått igjennom artiklene.

Denne fiksen plukker ut og oppdaterer noden direkte med nodeLib og pusher kun hvis draft og master i utgangspunktet var den samme.

## Testing
Testes i dev