### PR TITLE
Slår midlertidig av push av artikkelliste etter vask

### DIFF
--- a/src/main/resources/lib/contentlists/remove-unpublished.ts
+++ b/src/main/resources/lib/contentlists/remove-unpublished.ts
@@ -88,12 +88,14 @@ const removeUnpublishedFromContentList = (
             });
 
             if (shouldPushChanges) {
+                /*
                 repoConnection.commit({ keys: contentList._id });
                 repoConnection.push({
                     key: contentList._id,
                     target: 'master',
                     includeChildren: false,
                 });
+                */
             } else {
                 log.info(
                     `Removed unpublished content from content list ${contentList._id}, but draft and master are out of sync, so not pushing changes.`


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Midlertidig stopper push av innholdslister. Denne tar med seg for mye annet.

## Testing
Testet i dev