### PR TITLE
Slår av mulighet for å sette inn Filtreringsmeny

### DIFF
--- a/.xp-codegen/site/layouts/product-flex-cols/index.d.ts
+++ b/.xp-codegen/site/layouts/product-flex-cols/index.d.ts
@@ -14,9 +14,4 @@ export type ProductFlexCols = {
    * Ikke vis under innhold
    */
   hideFromInternalNavigation: boolean;
-
-  /**
-   * Toggle "kopier lenke" knapp
-   */
-  toggleCopyButton: boolean;
 };

--- a/.xp-codegen/site/mixins/header-with-anchor/index.d.ts
+++ b/.xp-codegen/site/mixins/header-with-anchor/index.d.ts
@@ -14,9 +14,4 @@ export type HeaderWithAnchor = {
    * Ikke vis under innhold
    */
   hideFromInternalNavigation: boolean;
-
-  /**
-   * Toggle "kopier lenke" knapp
-   */
-  toggleCopyButton: boolean;
 };

--- a/src/main/resources/site/parts/filters-menu/filters-menu.xml
+++ b/src/main/resources/site/parts/filters-menu/filters-menu.xml
@@ -31,4 +31,7 @@
         </item-set>
         <mixin name="expandable"/>
     </form>
+    <config>
+        <allow-on-content-type>none</allow-on-content-type>
+    </config>
 </part>


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Denne fiksen påvirker bare mulighet for å sette inn en ny part for Filtreringsmeny. Versjonshistorikk og visning av sider da de tidligere hadde filtreringsmeny vil fungere som før. Det samme gjelder dersom man reverter en side til en tidligere versjon hvor Filtreringsmeny fantes.

## Testing
Testes i dev
