### PR TITLE
Endrer innholds-typer for siteContentPaths ved flagg 'test'

### DIFF
--- a/src/main/resources/services/sitecontentPaths/sitecontentPaths.ts
+++ b/src/main/resources/services/sitecontentPaths/sitecontentPaths.ts
@@ -21,7 +21,8 @@ const cache = cacheLib.newCache({ size: 2, expire: 600 });
 // Limited selection of content types for testing purposes
 // (we don't want to build all 17000+ pages on every deploy while testing :)
 const testContentTypes: ContentDescriptor[] = [
-    'no.nav.navno:dynamic-page',
+    'no.nav.navno:front-page',
+    'no.nav.navno:area-page',
     'no.nav.navno:content-page-with-sidemenus',
     'no.nav.navno:situation-page',
 ];


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Ved sending av "test"-flagg inkluder områdesider og oversatte forsider (dvs ikke bare "/")

## Testing
Testet i dev