### PR TITLE
Forbedre visning og søkbarhet av kontorsteder

### DIFF
--- a/src/main/resources/lib/office-pages/types.ts
+++ b/src/main/resources/lib/office-pages/types.ts
@@ -13,6 +13,3 @@ const OFFICE_PAGE_TYPES = [
 
 export const isOfficeContent = (content: Content): content is OfficeContent =>
     OFFICE_PAGE_TYPES.includes((content as OfficeContent).type);
-
-export const isOfficePage = (content: Content): content is OfficePage =>
-    content.type === 'no.nav.navno:office-page';

--- a/src/main/resources/lib/office-pages/types.ts
+++ b/src/main/resources/lib/office-pages/types.ts
@@ -2,6 +2,9 @@ import { Content } from '/lib/xp/content';
 import { ContentDescriptor } from '../../types/content-types/content-config';
 
 export type OfficeContent = Content<(typeof OFFICE_PAGE_TYPES)[number]>;
+export type OfficePage = Content<
+    Extract<(typeof OFFICE_PAGE_TYPES)[number], 'no.nav.navno:office-page'>
+>;
 
 const OFFICE_PAGE_TYPES = [
     'no.nav.navno:office-information',
@@ -10,3 +13,6 @@ const OFFICE_PAGE_TYPES = [
 
 export const isOfficeContent = (content: Content): content is OfficeContent =>
     OFFICE_PAGE_TYPES.includes((content as OfficeContent).type);
+
+export const isOfficePage = (content: Content): content is OfficePage =>
+    content.type === 'no.nav.navno:office-page';

--- a/src/main/resources/lib/office-pages/types.ts
+++ b/src/main/resources/lib/office-pages/types.ts
@@ -13,3 +13,7 @@ const OFFICE_PAGE_TYPES = [
 
 export const isOfficeContent = (content: Content): content is OfficeContent =>
     OFFICE_PAGE_TYPES.includes((content as OfficeContent).type);
+
+export type Publikumsmottak = NonNullable<
+    OfficePage['data']['officeNorgData']['data']['brukerkontakt']
+>['publikumsmottak'];

--- a/src/main/resources/lib/search/document-builder/document-builder.ts
+++ b/src/main/resources/lib/search/document-builder/document-builder.ts
@@ -110,7 +110,7 @@ class ExternalSearchDocumentBuilder {
                 type: getSearchDocumentContentType(content),
                 createdAt: publishedTime,
                 lastUpdated: content.modifiedTime || publishedTime,
-                keywords: this.getKeywords(content),
+                keywords: forceArray(content.data.keywords),
                 languageRefs: getSearchDocumentLanguageRefs(content),
             },
         };
@@ -175,22 +175,6 @@ class ExternalSearchDocumentBuilder {
                   this.getFirstMatchingFieldValue('ingressKey') ||
                       this.getFirstMatchingFieldValue('textKey')
               );
-    }
-
-    private getKeywords(content: ContentNode): string[] {
-        if (isOfficePage(content)) {
-            const poststeder = forceArray(
-                content.data.officeNorgData.data.brukerkontakt?.publikumsmottak
-            ).map((mottak) => mottak.besoeksadresse?.poststed);
-
-            const adresser = forceArray(
-                content.data.officeNorgData.data.brukerkontakt?.publikumsmottak
-            ).map((mottak) => mottak.besoeksadresse?.gatenavn);
-
-            return [...poststeder, ...adresser].filter((item): item is string => !!item);
-        }
-
-        return forceArray(content.data.keywords);
     }
 
     private getText(): string {

--- a/src/main/resources/lib/search/document-builder/document-builder.ts
+++ b/src/main/resources/lib/search/document-builder/document-builder.ts
@@ -27,7 +27,7 @@ import {
     getSearchDocumentLanguage,
     getSearchDocumentLanguageRefs,
 } from './field-resolvers/language';
-import { isOfficeContent, isOfficePage } from '../../office-pages/types';
+import { isOfficeContent } from '../../office-pages/types';
 import {
     buildSearchDocumentIngress,
     buildSearchDocumentOfficeIngress,

--- a/src/main/resources/lib/search/document-builder/field-resolvers/ingress.ts
+++ b/src/main/resources/lib/search/document-builder/field-resolvers/ingress.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../../utils/logging';
-import { OfficeContent, OfficePage } from '../../../office-pages/types';
+import { OfficeContent, Publikumsmottak } from '../../../office-pages/types';
 import { forceArray, removeDuplicatesFilter } from '../../../utils/array-utils';
 import { capitalize } from '../../../utils/string-utils';
 
@@ -7,32 +7,23 @@ const INGRESS_MAX_LENGTH = 500;
 
 const DEFAULT_OFFICE_INGRESS = 'Kontorinformasjon';
 
-type Publikumsmottak = NonNullable<
-    OfficePage['data']['officeNorgData']['data']['brukerkontakt']
->['publikumsmottak'];
-
 const getSted = (publikumsmottak: Publikumsmottak) => {
     if (!publikumsmottak || publikumsmottak.length === 0) {
         return [DEFAULT_OFFICE_INGRESS];
     }
 
     // For offices with only one publikumsmottak, the 'stedsbeskrivelse' key
-    // will not be actively used and may contain strange texts
-    // (ie "Andeby torg, inngang ved postkontoret rundt hjørnet").
-    // In these cases, use the postal city.
+    // is not actively used has therefore has not been cleaned by editors in NORG.
+    // It may contain strange texts in NORG (ie "Andeby torg, inngang ved postkontoret rundt hjørnet").
+    // This is why we use poststed when only 1 publikumsmottak.
     if (publikumsmottak.length === 1) {
         return [capitalize(publikumsmottak[0].besoeksadresse?.poststed ?? '')];
     }
 
-    // For offices with multiple publikumsmottak, try stedsbeskrivelse and then poststed if
-    // stedsbeskrivelse doesn't exist. This makes the display match the tagline on the office page,
-    // and in these cases the stedsbeskrivelse field in Norg is already cleaned since it's
-    // used in the tabs for the office page.
+    // For offices with multiple publikumsmottak, the stedsbeskrivelse has been cleaned by editors
+    // as it is used in the tabs at the top of an office page.
     return forceArray(publikumsmottak)
-        .filter(
-            (mottak) =>
-                mottak.besoeksadresse?.type === 'stedsadresse' && !!mottak.besoeksadresse.poststed
-        )
+        .filter((mottak) => mottak.besoeksadresse?.type === 'stedsadresse')
         .map((mottak) =>
             capitalize(mottak.stedsbeskrivelse ?? mottak.besoeksadresse?.poststed ?? '')
         )

--- a/src/main/resources/lib/search/document-builder/field-resolvers/ingress.ts
+++ b/src/main/resources/lib/search/document-builder/field-resolvers/ingress.ts
@@ -11,22 +11,22 @@ type Publikumsmottak = NonNullable<
     OfficePage['data']['officeNorgData']['data']['brukerkontakt']
 >['publikumsmottak'];
 
-const getStedsnavn = (publikumsmottak: Publikumsmottak) => {
+const getSted = (publikumsmottak: Publikumsmottak) => {
     if (!publikumsmottak || publikumsmottak.length === 0) {
         return [DEFAULT_OFFICE_INGRESS];
     }
 
-    // For offices with only one publikumsmottak, the stedsnavn
+    // For offices with only one publikumsmottak, the 'stedsbeskrivelse' key
     // will not be actively used and may contain strange texts
-    // (ie "Lesja, inngang ved postkontoret rundt hjørnet").
+    // (ie "Andeby torg, inngang ved postkontoret rundt hjørnet").
     // In these cases, use the postal city.
     if (publikumsmottak.length === 1) {
         return [capitalize(publikumsmottak[0].besoeksadresse?.poststed ?? '')];
     }
 
-    // For offices with multiple publikumsmottak, try stedsnavn and then poststed if
-    // stedsnavn doesn't exist. This makes the display match the tagline on the office page,
-    // and in these cases the stedsnavn field in Norg is already cleaned since it's
+    // For offices with multiple publikumsmottak, try stedsbeskrivelse and then poststed if
+    // stedsbeskrivelse doesn't exist. This makes the display match the tagline on the office page,
+    // and in these cases the stedsbeskrivelse field in Norg is already cleaned since it's
     // used in the tabs for the office page.
     return forceArray(publikumsmottak)
         .filter(
@@ -60,7 +60,7 @@ export const buildSearchDocumentOfficeIngress = (content: OfficeContent) => {
         return officeData.navn; // i.e "NAV Hjelpemiddelsentral i Oslo"
     }
 
-    const steder = getStedsnavn(officeData.brukerkontakt?.publikumsmottak);
+    const steder = getSted(officeData.brukerkontakt?.publikumsmottak);
 
     if (steder.length === 0) {
         return DEFAULT_OFFICE_INGRESS;

--- a/src/main/resources/lib/search/document-builder/field-resolvers/ingress.ts
+++ b/src/main/resources/lib/search/document-builder/field-resolvers/ingress.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../../utils/logging';
-import { OfficeContent } from '../../../office-pages/types';
+import { OfficeContent, OfficePage } from '../../../office-pages/types';
 import { forceArray, removeDuplicatesFilter } from '../../../utils/array-utils';
 import { capitalize } from '../../../utils/string-utils';
 
@@ -7,7 +7,11 @@ const INGRESS_MAX_LENGTH = 500;
 
 const DEFAULT_OFFICE_INGRESS = 'Kontorinformasjon';
 
-const getStedsnavn = (publikumsmottak: any) => {
+type Publikumsmottak = NonNullable<
+    OfficePage['data']['officeNorgData']['data']['brukerkontakt']
+>['publikumsmottak'];
+
+const getStedsnavn = (publikumsmottak: Publikumsmottak) => {
     if (!publikumsmottak || publikumsmottak.length === 0) {
         return [DEFAULT_OFFICE_INGRESS];
     }
@@ -29,7 +33,9 @@ const getStedsnavn = (publikumsmottak: any) => {
             (mottak) =>
                 mottak.besoeksadresse?.type === 'stedsadresse' && !!mottak.besoeksadresse.poststed
         )
-        .map((mottak) => capitalize(mottak.stedsnavn ?? mottak.besoeksadresse?.poststed ?? ''))
+        .map((mottak) =>
+            capitalize(mottak.stedsbeskrivelse ?? mottak.besoeksadresse?.poststed ?? '')
+        )
         .filter(removeDuplicatesFilter())
         .filter((navn) => !!navn);
 };


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Enkelte kontorer har stedsnavn (stort sett kommunenavn) som ikke er de samme som poststedet hvor kontoret ligger. Derfor vises for eksempel ikke Nav Midt-Buskerud når man søker på "Sigdal" som er publikumsmottaket i Sigdal kommune.

Denne fiksen prioriterer `stedsbeskrivelse` dersom et Nav-kontor har flere publikumsmottak OG stedsbeskrivelse finnes. Det er det samme feltet som bruker i fanene for å velge publikumsmottak.

## Testing
Testes i dev