### PR TITLE
Add more curated types to standard search for the external archive

### DIFF
--- a/src/main/resources/services/externalArchive/search/search.ts
+++ b/src/main/resources/services/externalArchive/search/search.ts
@@ -24,6 +24,9 @@ export const externalArchiveSearchService = (req: XP.Request) => {
             'no.nav.navno:current-topic-page',
             'no.nav.navno:external-link',
             'no.nav.navno:internal-link',
+            'no.nav.navno:product-details',
+            'no.nav.navno:global-case-time-set',
+            'no.nav.navno:payout-dates',
         ];
 
         const excludeTypes = ` AND NOT type IN (${curatedTypes.map((t) => `"${t}"`).join(',')})`;


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Lagt til utvidelse av typer som dukker opp i standard søk til å inneholde Produktdetaljer, Saksbehandlingstide og Utbetalingsdatoer.
