### PR TITLE
Starter fast arkiveringschedule (test foreløpig i dev)

### DIFF
--- a/src/main/resources/lib/archiving/archive-old-news.ts
+++ b/src/main/resources/lib/archiving/archive-old-news.ts
@@ -8,7 +8,7 @@ import { findAndArchiveOldContent } from './batch-archiving';
 
 const ONE_YEAR_MS = 1000 * 3600 * 24 * 365;
 
-const MONDAY_0500_CRON = '0 5 * * 1';
+const MONDAY_0500_CRON = '0 4 * * 1';
 
 const pressReleasesQuery: QueryDsl = {
     boolean: {

--- a/src/main/resources/lib/archiving/batch-archiving.ts
+++ b/src/main/resources/lib/archiving/batch-archiving.ts
@@ -154,6 +154,12 @@ const unpublishAndArchiveContents = (
         //     );
         // }
 
+        // Content is published and has a publish date that is newer than the cutoff date,
+        // so it should not be unpublished. This is not an error, so don't push to the errors array.
+        if (contentFinal.publish?.from && contentFinal.publish.from > cutoffTs) {
+            return;
+        }
+
         // If the content has inbound references, don't unpublish as it may lead to broken links etc
         if (contentFinal.references.length > 0) {
             contentFinal.errors.push('Innholdet har innkommende avhengigheter');

--- a/src/main/resources/main.ts
+++ b/src/main/resources/main.ts
@@ -45,8 +45,10 @@ activateLayersEventListeners();
 activateCacheEventListeners();
 activateContentListItemUnpublishedListener();
 activateExternalSearchIndexEventHandlers();
-// Wait for further discussion on how to handle periodic archiving
-// activateArchiveNewsSchedule();
+
+if (app.config.env !== 'p') {
+    activateArchiveNewsSchedule();
+}
 
 activateCustomPathNodeListeners();
 activateContentUpdateListener();


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Starter fast arkivering hver mandag kl 05:00 (vinter) og 06:00 (sommer)
- Tar hensyn til om elementet ble publisert (eller republisert) mindre enn 1 år siden.

## Testing
Testes I dev i et par ukers tid av Janne og Kristin. Prod-blocken fjernes 28. april.