### PR TITLE
Fiks slik at vi ikke viser migrerte versjoner i default, men i layers

### DIFF
--- a/src/main/resources/lib/external-archive/content-tree-archive.ts
+++ b/src/main/resources/lib/external-archive/content-tree-archive.ts
@@ -86,8 +86,9 @@ class ArchiveContentTree {
                     mustNot: [
                         ...NON_LOCALIZED_QUERY_FILTER,
                         {
-                            exists: {
-                                field: 'data._layerMigration',
+                            hasValue: {
+                                field: 'data._layerMigration.locale',
+                                values: ['nn', 'en', 'se'],
                             },
                         },
                     ],

--- a/src/main/resources/services/dataQuery/utils/queryBuilder.ts
+++ b/src/main/resources/services/dataQuery/utils/queryBuilder.ts
@@ -88,7 +88,6 @@ export const getNodeHitsFromExternalArchiveQuery = ({
                 boolean: {
                     must: [
                         { notExists: { field: 'data.externalProductUrl' } },
-                        { notExists: { field: 'data._layerMigration' } },
                         {
                             hasValue: {
                                 field: 'type',
@@ -108,6 +107,12 @@ export const getNodeHitsFromExternalArchiveQuery = ({
                             hasValue: {
                                 field: 'x.no-nav-navno.previewOnly.previewOnly',
                                 values: ['true'],
+                            },
+                        },
+                        {
+                            hasValue: {
+                                field: 'data._layerMigration.locale',
+                                values: ['nn', 'en', 'se'],
                             },
                         },
                     ],


### PR DESCRIPTION
## Oppsummering av hva som er gjort
-   Endrer filter i søk og innholdstre i layers for å fikse de med migrert data

## Testing

Eks: Har testet selv i dev