### PR TITLE
Forbedrer navning og cronjobb for office-importering

### DIFF
--- a/src/main/resources/lib/office-pages/_legacy-office-information/legacy-office-update.ts
+++ b/src/main/resources/lib/office-pages/_legacy-office-information/legacy-office-update.ts
@@ -280,10 +280,10 @@ export const runOfficeInfoUpdateTask = (retry: boolean, scheduledTime?: string) 
     }
 };
 
-export const startOfficeInfoPeriodicUpdateSchedule = () => {
+export const createLegacyOfficeImportSchedule = () => {
     createOrUpdateSchedule<UpdateOfficeInfo>({
-        jobName: 'office_info_norg2_hourly',
-        jobDescription: 'Updates legacy office information from norg2 every hour',
+        jobName: 'legacy_office_import_schedule',
+        jobDescription: 'Imports and updates legacy office information from norg2 every 10 minutes',
         jobSchedule: {
             type: 'CRON',
             value: '*/10 * * * *',

--- a/src/main/resources/lib/office-pages/office-tasks.ts
+++ b/src/main/resources/lib/office-pages/office-tasks.ts
@@ -5,7 +5,7 @@ import { processAllOffices, fetchAllOfficeDataFromNorg } from './office-update';
 import { runInContext } from '../context/run-in-context';
 
 const OFFICE_FETCH_TASK_NAME = 'no.nav.navno:update-office';
-const CRON_SCHEDULE = app.config.env === 'localhost' ? '*/3 * * * *' : '* * * * *';
+const CRON_SCHEDULE = app.config.env === 'localhost' ? '*/10 * * * *' : '* * * * *';
 
 const MAX_FAILURE_COUNT_BEFORE_CRITICAL = 10;
 
@@ -34,10 +34,11 @@ export const runOfficeFetchTask = () => {
     );
 };
 
-export const createOfficeFetchSchedule = () => {
+export const createOfficeImportSchedule = () => {
     createOrUpdateSchedule({
-        jobName: 'office_update_from_norg2_schedule',
-        jobDescription: 'Fetches office from norg and updates into XP as hourly schedule',
+        jobName: 'office_import_schedule',
+        jobDescription:
+            'Imports and updates legacy office information from norg2 every minute (or every 10 minutes in localhost)',
         jobSchedule: {
             type: 'CRON',
             value: CRON_SCHEDULE,

--- a/src/main/resources/main.ts
+++ b/src/main/resources/main.ts
@@ -10,10 +10,10 @@ import {
     generateSitemapDataAndActivateSchedule,
 } from './lib/sitemap/sitemap';
 import { updateClusterInfo } from './lib/cluster-utils/cluster-api';
-import { startOfficeInfoPeriodicUpdateSchedule } from './lib/office-pages/_legacy-office-information/legacy-office-update';
+import { createLegacyOfficeImportSchedule } from './lib/office-pages/_legacy-office-information/legacy-office-update';
 import { activateContentListItemUnpublishedListener } from './lib/contentlists/remove-unpublished';
 import { activateCustomPathNodeListeners } from './lib/paths/custom-paths/custom-path-event-listeners';
-import { createOfficeFetchSchedule } from './lib/office-pages/office-tasks';
+import { createOfficeImportSchedule } from './lib/office-pages/office-tasks';
 import { hookLibsWithTimeTravel } from './lib/time-travel/time-travel-hooks';
 import { initMiscRepo } from './lib/repos/misc-repo';
 import { initLayersData } from './lib/localization/layers-data';
@@ -36,8 +36,8 @@ if (clusterLib.isMaster()) {
 }
 
 if (app.config.env !== 'test') {
-    createOfficeFetchSchedule();
-    startOfficeInfoPeriodicUpdateSchedule();
+    createOfficeImportSchedule();
+    createLegacyOfficeImportSchedule();
     activateSitemapDataUpdateEventListener();
 }
 


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Importjobbene for kontor-import hadde stoppet. Jeg sletter schedule-nodene og deployer på nytt, men benytter samtidig anledningen til bedre jobb-navn slik at det er lettere å skille mellom hva som er "ny" kontorimport og hva som er legacy (som vi kanskje snart kan droppe...

## Testing
Testet i q6

