### PR TITLE
Aktivere mandagsarkivering. Unntak for aktuelt-artikler med planlag avpublisering

### DIFF
--- a/src/main/resources/lib/archiving/batch-archiving.ts
+++ b/src/main/resources/lib/archiving/batch-archiving.ts
@@ -142,21 +142,19 @@ const unpublishAndArchiveContents = (
     const skippedContent: ContentDataSimple[] = [];
 
     contents.forEach((content) => {
-        // Change: We want the archiving to be more greedy, so don't check for inbound references.
-        const references: ContentDataSimple[] = []; // getRelevantReferences(content, repoId);
+        const references: ContentDataSimple[] = [];
 
         const contentFinal: ContentDataSimple = {
             ...content,
             references,
         };
 
-        // Change: We want the archiving to be more greedy, so don't check for newer
-        // descendants. This might change in the near future, so keep it commented out for now.
-        // if (hasNewerDescendants(content, cutoffTs)) {
-        //     contentFinal.errors.push(
-        //         'Innholdet har under-innhold som er nyere enn tidsavgrensingen for arkivering'
-        //     );
-        // }
+        // Content of type 'no.nav.navno:current-topic-page' should not be archived
+        // if it has a publish?.to date set.
+        if (contentFinal.type === 'no.nav.navno:current-topic-page' && contentFinal.publish?.to) {
+            skippedContent.push(contentFinal);
+            return;
+        }
 
         // Content is published and has a publish date that is newer than the cutoff date,
         // so it should not be unpublished. This is not an error, so don't push to the errors array.

--- a/src/main/resources/main.ts
+++ b/src/main/resources/main.ts
@@ -46,8 +46,7 @@ activateCacheEventListeners();
 activateContentListItemUnpublishedListener();
 activateExternalSearchIndexEventHandlers();
 
-// Disable this for now until we found cause if publishing issues
-// activateArchiveNewsSchedule();
+activateArchiveNewsSchedule();
 
 activateCustomPathNodeListeners();
 activateContentUpdateListener();


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Reaktiverer schedule for arkivering av pressemeldinger, nyheter og aktuelt-sider hver mandags morgen.
- Setter inn unntak for aktuelt-sider: Kun aktueltsider som ikke har noen planlagt avpublisering (dvs som bare blir liggende i evig tid) skal arkiveres når from er mer en 1 år bakover i tid. Utover det skal de få ligge.
- Fjerner utkommentert kode om sjekk av referanser. Det er ikke ønskelig å ta denne funksjonen inn igjen i det heletatt.

## Testing
Testes i dev med utvalgte artikler. Sjekkes mandags morgen at alt er OK
