### PR TITLE
Hardkode navn pa regions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     include "com.enonic.xp:lib-project:${xpVersion}"
     include "com.enonic.xp:lib-repo:${xpVersion}"
     include "com.enonic.xp:lib-scheduler:${xpVersion}"
+    include "com.enonic.xp:lib-schema:${xpVersion}"
     include "com.enonic.xp:lib-task:${xpVersion}"
     include "com.enonic.xp:lib-value:${xpVersion}"
     include "com.enonic.xp:lib-websocket:${xpVersion}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
                 "@enonic-types/lib-project": "7.15.0",
                 "@enonic-types/lib-repo": "7.15.0",
                 "@enonic-types/lib-scheduler": "7.15.0",
+                "@enonic-types/lib-schema": "7.15.0",
                 "@enonic-types/lib-task": "7.15.0",
                 "@enonic-types/lib-value": "7.15.0",
                 "@enonic-types/lib-websocket": "7.15.0",
@@ -2077,6 +2078,16 @@
             "version": "7.15.0",
             "resolved": "https://registry.npmjs.org/@enonic-types/lib-scheduler/-/lib-scheduler-7.15.0.tgz",
             "integrity": "sha512-Byt4U9YP2ZBoqiMyH49eFIlwaSWQ7Kd3VXOj/15IstIQ+c2+7TbWNerGoYpTZ455TtuLDcTmLc3u0rXDZC+Rkw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@enonic-types/core": "7.15.0"
+            }
+        },
+        "node_modules/@enonic-types/lib-schema": {
+            "version": "7.15.0",
+            "resolved": "https://registry.npmjs.org/@enonic-types/lib-schema/-/lib-schema-7.15.0.tgz",
+            "integrity": "sha512-XE2apa/mGOXx7cC/a36RYGOh4DLA2OK48yuBbrBeRHXyZ8JPgRaEafRs2/WtzQ/hrQq3LxhfKe7N8BViogL5Ow==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "@enonic-types/lib-project": "7.15.0",
         "@enonic-types/lib-repo": "7.15.0",
         "@enonic-types/lib-scheduler": "7.15.0",
+        "@enonic-types/lib-schema": "7.15.0",
         "@enonic-types/lib-task": "7.15.0",
         "@enonic-types/lib-value": "7.15.0",
         "@enonic-types/lib-websocket": "7.15.0",

--- a/src/main/resources/lib/controllers/component-preview-controller.ts
+++ b/src/main/resources/lib/controllers/component-preview-controller.ts
@@ -1,4 +1,4 @@
-import { Request } from '@enonic-types/core'
+import { Request } from '@enonic-types/core';
 import * as portalLib from '/lib/xp/portal';
 import httpClient from '/lib/http-client';
 import { URLS } from '../constants';
@@ -6,6 +6,7 @@ import { logger } from '../utils/logging';
 import { runGuillotineComponentPreviewQuery } from '../guillotine/queries/run-sitecontent-query';
 import {
     destructureComponent,
+    getSchemaRegionsDictionary,
     insertComponentsIntoRegions,
 } from '../guillotine/utils/process-components';
 import { runGuillotineContentQuery } from '../guillotine/queries/run-content-query';
@@ -59,9 +60,16 @@ const getComponentProps = () => {
         return rootFragment;
     }
 
+    const regionsDictionary = getSchemaRegionsDictionary();
+
     // Layouts must include components in its regions
     if (portalComponent.type === 'layout') {
-        return insertComponentsIntoRegions(portalComponent, components, fragments);
+        return insertComponentsIntoRegions({
+            parentComponent: portalComponent,
+            components,
+            fragments,
+            regionsDictionary,
+        });
     }
 
     // Parts need to be destructured into the structure the frontend expects for rendering

--- a/src/main/resources/lib/guillotine/utils/process-components.ts
+++ b/src/main/resources/lib/guillotine/utils/process-components.ts
@@ -118,7 +118,7 @@ const insertMissingRegions = ({
         return regions || {};
     }
 
-    return Object.entries(expectedRegions).reduce<Regions>((acc, [regionName]) => {
+    return expectedRegions.reduce<Regions>((acc, regionName) => {
         const augmentedRegion = (regions && regions[regionName]) ?? {
             name: regionName,
             components: [],

--- a/test/unit-tests/tsconfig.json
+++ b/test/unit-tests/tsconfig.json
@@ -33,6 +33,7 @@
             "/lib/xp/project": ["node_modules/@enonic-types/lib-project"],
             "/lib/xp/repo": ["node_modules/@enonic-types/lib-repo"],
             "/lib/xp/scheduler": ["node_modules/@enonic-types/lib-scheduler"],
+            "/lib/xp/schema": ["node_modules/@enonic-types/lib-schema"],
             "/lib/xp/task": ["node_modules/@enonic-types/lib-task"],
             "/lib/xp/value": ["node_modules/@enonic-types/lib-value"],
             "/lib/xp/websocket": ["node_modules/@enonic-types/lib-websocket"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,7 @@
             "/lib/xp/io": ["../../../node_modules/@enonic-types/lib-io"],
             "/lib/xp/node": ["types/xp-libs/lib-node"],
             "/lib/xp/portal": ["types/xp-libs/lib-portal"],
+            "/lib/xp/schema": ["../../../node_modules/@enonic-types/lib-schema"],
             "/lib/xp/project": ["../../../node_modules/@enonic-types/lib-project"],
             "/lib/xp/repo": ["../../../node_modules/@enonic-types/lib-repo"],
             "/lib/xp/scheduler": ["../../../node_modules/@enonic-types/lib-scheduler"],


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Fra 7.13.1 ble ikke tomme regioner levert til frontend. Enkelte layouts og komponenter i frontend forventer uansett disse slik at redaktørene på et tidspunkt kan velge å fylle regionene med innhold.

Frem til nå har vi løst det med resolveEmptyRegions=true i innstillinger, men denne funksjonen er deprecated og blir på sikt fjernet (trolig i XP8).

Denne PR'en henter ut schema for PAGE og LAYUT (PART har ingen regioner) og setter inn tomme regioner der de ikke finnes (men forventes i schema).

## Testing
Testet innledningsvis i q6, men vi trenger hjelp til å få fjernet resolveEmptyRegions fra innstillingene før vi kan teste det ordentlig.