### PR TITLE
Fjerner sjekk på slik-gjør-du-det

### DIFF
--- a/.xp-codegen/site/content-types/guide-page/index.d.ts
+++ b/.xp-codegen/site/content-types/guide-page/index.d.ts
@@ -16,7 +16,7 @@ export type GuidePage = {
   norwegianTitle?: string;
 
   /**
-   * Ikke vis denne siden på oversiktssider (gjelder ikke skjemaoversikter)
+   * Kun oversiktsside v1: Ikke vis denne siden på oversiktssider (gjelder ikke skjemaoversikter)
    */
   hideFromProductlist: boolean;
 

--- a/src/main/resources/lib/overview-pages/oversikt-v3/helpers.ts
+++ b/src/main/resources/lib/overview-pages/oversikt-v3/helpers.ts
@@ -73,12 +73,6 @@ export const getOversiktContent = ({ oversiktType, audience, excludedContentIds 
                             values: [true],
                         },
                     },
-                    {
-                        hasValue: {
-                            field: 'data.hideFromProductlist',
-                            values: [true],
-                        },
-                    },
                     ...(excludedContentIds.length > 0
                         ? [
                               {
@@ -94,6 +88,5 @@ export const getOversiktContent = ({ oversiktType, audience, excludedContentIds 
         },
     };
 
-    logger.info(JSON.stringify(query, null, 2));
     return contentLib.query(query).hits;
 };

--- a/src/main/resources/site/content-types/guide-page/guide-page.xml
+++ b/src/main/resources/site/content-types/guide-page/guide-page.xml
@@ -10,7 +10,7 @@
             <items>
                 <mixin name="page-header"/>
                 <input type="CheckBox" name="hideFromProductlist">
-                    <label>Ikke vis denne siden på oversiktssider (gjelder ikke skjemaoversikter)</label>
+                    <label>Kun oversiktsside v1: Ikke vis denne siden på oversiktssider (gjelder ikke skjemaoversikter)</label>
                     <default>unchecked</default>
                 </input>
                 <mixin name="ingress-required" />


### PR DESCRIPTION
## Oppsummering av hva som er gjort
"Slik gjør du det" skal ikke ha egen avkryssning for å utelate den fra oversiktssider. Det skal gjøres fra selve oversiktssiden i stedet. Merk: sjekkboksen må fortsatt være er til vi har lansert de nye oversiktssidene.

## Testing
Testes i dev