### PR TITLE
Utvider logging ved manglende contentId

### DIFF
--- a/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/oversikt-data-callback.ts
+++ b/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/oversikt-data-callback.ts
@@ -1,4 +1,5 @@
 import * as contentLib from '/lib/xp/content';
+import * as contextLib from '/lib/xp/context';
 import graphQlLib from '/lib/graphql';
 import { CreationCallback, graphQlCreateObjectType } from '../../utils/creation-callback-utils';
 import { logger } from '../../../utils/logging';
@@ -14,7 +15,6 @@ import { buildBasicServicesList } from '../../../overview-pages/oversikt-v3/basi
 import { getOversiktCategory } from '../../../../lib/overview-pages/oversikt-v3/helpers';
 
 const buildItemList = (content: contentLib.Content<'no.nav.navno:oversikt'>) => {
-    logger.info(`Building item list for content with ID: ${content.data.oversiktType}`);
     if (getOversiktCategory(content.data.oversiktType) === 'formDetails') {
         return buildFormDetailsList(content);
     } else if (getOversiktCategory(content.data.oversiktType) === 'productDetails') {
@@ -87,7 +87,10 @@ export const oversiktDataCallback: CreationCallback = (context, params) => {
         resolve: () => {
             const contentId = getGuillotineContentQueryBaseContentId();
             if (!contentId) {
-                logger.error('No contentId provided for overview-page resolver');
+                const context = contextLib.get();
+                logger.error(
+                    `No contentId provided for overview-page resolver: ${JSON.stringify(context)}`
+                );
                 return [];
             }
 

--- a/src/main/resources/lib/overview-pages/oversikt-v3/form-details-utils.ts
+++ b/src/main/resources/lib/overview-pages/oversikt-v3/form-details-utils.ts
@@ -56,7 +56,6 @@ export const buildFormDetailsList = (formsOverviewContent: Content<'no.nav.navno
     const { language, data, _id } = formsOverviewContent;
     const { oversiktType, audience, excludedContent, localeFallback } = data;
     const audienceAsArray = forceArray(audience);
-    logger.info('Running buildFormDetailsList');
 
     if (audienceAsArray.length === 0) {
         logger.error(`Audience not set for overview page ${_id} (${language})`);


### PR DESCRIPTION
## Oppsummering av hva som er gjort
- Sender ved context ved error-logging pga manglende contentId. Usikker på hvorfor den feiler, så trenger mer info. Mulig fordi redaktørene setter opp en ny oversiktsside som ikke har id ennå? 🤔 
- Fjerner litt unødvendig logging.

## Testing
Testes i dev