### PR TITLE
Sjekke om det faktisk er satt opp 'variations' i skjemadetalj

### DIFF
--- a/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/form-details.ts
+++ b/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/form-details.ts
@@ -40,6 +40,11 @@ const getFormNumbersFromVariations = (formType: FormDetails['formType']) => {
         const { _selected } = variation;
         const selectedVariation = (variation as any)[_selected];
 
+        // If the editor created a form-detail, didn't add any variations and just saved, we have nothing to extract.
+        if (!selectedVariation?.variations) {
+            return acc;
+        }
+
         const subFormNumbers: string[] = [];
         forceArray(selectedVariation.variations).forEach((variationItem) => {
             if (variationItem.link._selected === 'external') {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Det hender at redaktører setter opp skjemadetaljer uten å legge inn variasjoner. De får ikke publisert selvsagt, men frontend forsøker fortsatt å forhåndsvise skjemadetaljen og dette er en av årsakene til Internal Server Error som vi har hatt noen ganger.

Denne fiksen sjekker om det faktisk finnes `variations` før den forsøker å fiske ut skjemanummer.

## Testing
Testet i dev