### PR TITLE
Logger flere detaljer dersom indeksering av dokumenter feiler

### DIFF
--- a/src/main/resources/lib/search/api-handlers/post-document.ts
+++ b/src/main/resources/lib/search/api-handlers/post-document.ts
@@ -79,9 +79,7 @@ export const searchApiPostDocuments = (documents: SearchDocument[]) => {
                     // If something went wrong, log document info for investigation.
                     // Log full documents if batch is small, otherwise just IDs.
                     documents:
-                        logLevel === 'error' && documentsBatch.length <= 20
-                            ? documentsBatch
-                            : undefined,
+                        logLevel === 'error' ? documentsBatch : undefined,
                 })
             );
         } catch (e) {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Forbedrer logging når indeksering feiler slik at vi kan få noen id'er å gå etter.

## Testing
Testes i dev
