### PR TITLE
Fjerner whitespace før og etter i formDetails

### DIFF
--- a/src/main/resources/lib/contentUpdate/content-update-listener.ts
+++ b/src/main/resources/lib/contentUpdate/content-update-listener.ts
@@ -13,15 +13,7 @@ import { synchronizeMetaDataToLayers } from '../meta-synchronization/meta-synchr
 
 let hasContentUpdateListener = false;
 
-const contentTypesToMetaSynchronize = [
-    'no.nav.navno:content-page-with-sidemenus',
-    'no.nav.navno:situation-page',
-    'no.nav.navno:guide-page',
-    'no.nav.navno:themed-article-page',
-    'no.nav.navno:tools-page',
-    'no.nav.navno:current-topic-page',
-    'no.nav.navno:generic-page',
-];
+const contentTypesToMetaSynchronize = ['no.nav.navno:content-page-with-sidemenus', 'no.nav.navno:situation-page', 'no.nav.navno:guide-page', 'no.nav.navno:themed-article-page', 'no.nav.navno:tools-page', 'no.nav.navno:current-topic-page', 'no.nav.navno:generic-page'];
 
 const handleUpdateEvent = (event: eventLib.EnonicEvent) => {
     if (!isMainDatanode()) {
@@ -45,7 +37,10 @@ const handleUpdateEvent = (event: eventLib.EnonicEvent) => {
 
             switch (type) {
                 case 'no.nav.navno:form-details': {
-                    trimFormDetailsWhitespace(content);
+                    if (node.branch === 'draft') {
+                        trimFormDetailsWhitespace(content);
+                        break;
+                    }
                     break;
                 }
                 case 'no.nav.navno:video': {
@@ -54,8 +49,7 @@ const handleUpdateEvent = (event: eventLib.EnonicEvent) => {
                 }
                 case 'no.nav.navno:fragment-creator': {
                     transformFragmentCreatorToFragment({
-                        content,
-                        repoId: repo,
+                        content, repoId: repo,
                     });
                     break;
                 }
@@ -69,9 +63,7 @@ const handleUpdateEvent = (event: eventLib.EnonicEvent) => {
                 case 'no.nav.navno:global-case-time-set': {
                     if (repo !== CONTENT_ROOT_REPO_ID) {
                         const layerId = repo.replace(`${CONTENT_REPO_PREFIX}.`, '');
-                        logger.error(
-                            `Content on "${_path}" with type "${type}" was localized to layer "${layerId}" - reverting!`
-                        );
+                        logger.error(`Content on "${_path}" with type "${type}" was localized to layer "${layerId}" - reverting!`);
                         contentLib.resetInheritance({
                             key: id,
                             projectName: layerId,
@@ -120,12 +112,10 @@ export const activateContentUpdateListener = () => {
     hasContentUpdateListener = true;
 
     eventLib.listener({
-        type: 'node.updated',
-        callback: handleUpdateEvent,
+        type: 'node.updated', callback: handleUpdateEvent,
     });
 
     eventLib.listener({
-        type: 'node.pushed',
-        callback: handlePushedEvent,
+        type: 'node.pushed', callback: handlePushedEvent,
     });
 };

--- a/src/main/resources/lib/contentUpdate/content-update-listener.ts
+++ b/src/main/resources/lib/contentUpdate/content-update-listener.ts
@@ -13,7 +13,15 @@ import { synchronizeMetaDataToLayers } from '../meta-synchronization/meta-synchr
 
 let hasContentUpdateListener = false;
 
-const contentTypesToMetaSynchronize = ['no.nav.navno:content-page-with-sidemenus', 'no.nav.navno:situation-page', 'no.nav.navno:guide-page', 'no.nav.navno:themed-article-page', 'no.nav.navno:tools-page', 'no.nav.navno:current-topic-page', 'no.nav.navno:generic-page'];
+const contentTypesToMetaSynchronize = new Set([
+    'no.nav.navno:content-page-with-sidemenus',
+    'no.nav.navno:situation-page',
+    'no.nav.navno:guide-page',
+    'no.nav.navno:themed-article-page',
+    'no.nav.navno:tools-page',
+    'no.nav.navno:current-topic-page',
+    'no.nav.navno:generic-page']
+);
 
 const handleUpdateEvent = (event: eventLib.EnonicEvent) => {
     if (!isMainDatanode()) {
@@ -97,7 +105,7 @@ const handlePushedEvent = (event: eventLib.EnonicEvent) => {
 
             const { type } = content;
 
-            if (contentTypesToMetaSynchronize.includes(type)) {
+            if (contentTypesToMetaSynchronize.has(type)) {
                 synchronizeMetaDataToLayers(content, repo);
             }
         });

--- a/src/main/resources/lib/contentUpdate/content-update-listener.ts
+++ b/src/main/resources/lib/contentUpdate/content-update-listener.ts
@@ -45,11 +45,13 @@ const handleUpdateEvent = (event: eventLib.EnonicEvent) => {
 
             switch (type) {
                 case 'no.nav.navno:form-details': {
-                    if (node.branch === 'draft') {
-                        trimFormDetailsWhitespace(content);
+                    if (node.branch !== 'draft') {
                         break;
                     }
+
+                    runInContext({ asAdmin: true }, () => trimFormDetailsWhitespace(content));
                     break;
+                }
                 }
                 case 'no.nav.navno:video': {
                     updateQbrickVideoContent(content);

--- a/src/main/resources/lib/contentUpdate/content-update-listener.ts
+++ b/src/main/resources/lib/contentUpdate/content-update-listener.ts
@@ -5,6 +5,7 @@ import { CONTENT_REPO_PREFIX, CONTENT_ROOT_REPO_ID } from '../constants';
 import { transformFragmentCreatorToFragment } from '../content-transformers/fragment-creator';
 import { isContentLocalized } from '../localization/locale-utils';
 import { updateQbrickVideoContent } from './video-update';
+import { trimFormDetailsWhitespace } from './form-details-trim';
 import { logger } from '../utils/logging';
 import { isMainDatanode } from '../cluster-utils/main-datanode';
 import { contentDataLocaleFallbackRefreshItems } from './content-data-locale-fallback-update';
@@ -43,6 +44,10 @@ const handleUpdateEvent = (event: eventLib.EnonicEvent) => {
             const { _path, type } = content;
 
             switch (type) {
+                case 'no.nav.navno:form-details': {
+                    trimFormDetailsWhitespace(content);
+                    break;
+                }
                 case 'no.nav.navno:video': {
                     updateQbrickVideoContent(content);
                     break;

--- a/src/main/resources/lib/contentUpdate/content-update-listener.ts
+++ b/src/main/resources/lib/contentUpdate/content-update-listener.ts
@@ -20,7 +20,7 @@ const contentTypesToMetaSynchronize = new Set([
     'no.nav.navno:themed-article-page',
     'no.nav.navno:tools-page',
     'no.nav.navno:current-topic-page',
-    'no.nav.navno:generic-page']
+    'no.nav.navno:generic-page'],
 );
 
 const handleUpdateEvent = (event: eventLib.EnonicEvent) => {
@@ -57,7 +57,8 @@ const handleUpdateEvent = (event: eventLib.EnonicEvent) => {
                 }
                 case 'no.nav.navno:fragment-creator': {
                     transformFragmentCreatorToFragment({
-                        content, repoId: repo,
+                        content,
+                        repoId: repo,
                     });
                     break;
                 }
@@ -120,10 +121,12 @@ export const activateContentUpdateListener = () => {
     hasContentUpdateListener = true;
 
     eventLib.listener({
-        type: 'node.updated', callback: handleUpdateEvent,
+        type: 'node.updated',
+        callback: handleUpdateEvent,
     });
 
     eventLib.listener({
-        type: 'node.pushed', callback: handlePushedEvent,
+        type: 'node.pushed',
+        callback: handlePushedEvent,
     });
 };

--- a/src/main/resources/lib/contentUpdate/form-details-trim.ts
+++ b/src/main/resources/lib/contentUpdate/form-details-trim.ts
@@ -1,0 +1,136 @@
+import * as contentLib from '/lib/xp/content';
+import { Content } from '/lib/xp/content';
+import { FormDetails } from '@xp-types/site/content-types/form-details';
+import { forceArray } from '../utils/array-utils';
+import { logger } from '../utils/logging';
+
+type FormTypeVariation = FormDetails['formType'][number];
+type VariationItem = NonNullable<
+    | Extract<FormTypeVariation, { _selected: 'application' }>['application']['variations']
+    | Extract<FormTypeVariation, { _selected: 'complaint' }>['complaint']['variations']
+    | Extract<FormTypeVariation, { _selected: 'addendum' }>['addendum']['variations']
+>[number];
+
+const trimVariationItem = (
+    item: VariationItem,
+    onChanged: () => void
+): VariationItem => {
+    const trimmedLabel = item.label.trim();
+    if (trimmedLabel !== item.label) {
+        onChanged();
+    }
+
+    let link = item.link;
+    if (link._selected === 'external') {
+        const trimmedFormNumber = link.external.formNumber?.trim();
+        const trimmedUrl = link.external.url.trim();
+
+        if (trimmedFormNumber !== link.external.formNumber || trimmedUrl !== link.external.url) {
+            onChanged();
+            link = {
+                ...link,
+                external: {
+                    ...link.external,
+                    formNumber: trimmedFormNumber,
+                    url: trimmedUrl,
+                },
+            };
+        }
+    }
+
+    return { ...item, label: trimmedLabel, link };
+};
+
+const trimFormTypeVariation = (
+    variation: FormTypeVariation,
+    onChanged: () => void
+): FormTypeVariation => {
+    const selected = variation._selected;
+    const selectedData = (variation as Record<string, unknown>)[selected] as {
+        variations?: VariationItem[];
+    };
+
+    if (!selectedData?.variations) {
+        return variation;
+    }
+
+    const trimmedVariations = forceArray(selectedData.variations).map((item) =>
+        trimVariationItem(item, onChanged)
+    );
+
+    return {
+        ...variation,
+        [selected]: {
+            ...selectedData,
+            variations: trimmedVariations,
+        },
+    } as FormTypeVariation;
+};
+
+export const buildTrimmedFormDetailsData = (
+    data: FormDetails
+): { trimmedData: FormDetails; hasChanges: boolean } => {
+    let hasChanges = false;
+    const onChanged = () => {
+        hasChanges = true;
+    };
+
+    const trimOptional = (s?: string): string | undefined => {
+        if (s === undefined) return undefined;
+        const trimmed = s.trim();
+        if (trimmed !== s) onChanged();
+        return trimmed;
+    };
+
+    const title = data.title.trim();
+    if (title !== data.title) onChanged();
+
+    const longTitle = trimOptional(data.longTitle);
+    const languageDisclaimer = trimOptional(data.languageDisclaimer);
+
+    const originalFormNumbers = forceArray(data.formNumbers);
+    const trimmedFormNumbers = originalFormNumbers.map((n) => {
+        const trimmed = n.trim();
+        if (trimmed !== n) onChanged();
+        return trimmed;
+    });
+
+    const trimmedFormType = forceArray(data.formType).map((ft) =>
+        trimFormTypeVariation(ft, onChanged)
+    ) as FormDetails['formType'];
+
+    const trimmedData: FormDetails = {
+        ...data,
+        title,
+        longTitle,
+        languageDisclaimer,
+        formNumbers:
+            trimmedFormNumbers.length === 0
+                ? undefined
+                : trimmedFormNumbers.length === 1
+                  ? trimmedFormNumbers[0]
+                  : trimmedFormNumbers,
+        formType: trimmedFormType,
+    };
+
+    return { trimmedData, hasChanges };
+};
+
+export const trimFormDetailsWhitespace = (content: Content<'no.nav.navno:form-details'>) => {
+    const { trimmedData, hasChanges } = buildTrimmedFormDetailsData(content.data);
+
+    if (!hasChanges) {
+        return;
+    }
+
+    logger.info(`Trimming whitespace in form-details content: ${content._id}`);
+
+    contentLib.modify<'no.nav.navno:form-details'>({
+        key: content._id,
+        requireValid: false,
+        editor: (c) => {
+            c.data = trimmedData;
+            return c;
+        },
+    });
+};

--- a/src/main/resources/lib/contentUpdate/form-details-trim.ts
+++ b/src/main/resources/lib/contentUpdate/form-details-trim.ts
@@ -98,17 +98,19 @@ export const buildTrimmedFormDetailsData = (
         trimFormTypeVariation(ft, onChanged)
     ) as FormDetails['formType'];
 
+    const formNumbers =
+        trimmedFormNumbers.length === 0
+            ? undefined
+            : trimmedFormNumbers.length === 1
+              ? trimmedFormNumbers[0]
+              : trimmedFormNumbers;
+
     const trimmedData: FormDetails = {
         ...data,
         title,
         longTitle,
         languageDisclaimer,
-        formNumbers:
-            trimmedFormNumbers.length === 0
-                ? undefined
-                : trimmedFormNumbers.length === 1
-                  ? trimmedFormNumbers[0]
-                  : trimmedFormNumbers,
+        formNumbers,
         formType: trimmedFormType,
     };
 

--- a/src/main/resources/lib/contentUpdate/form-details-trim.ts
+++ b/src/main/resources/lib/contentUpdate/form-details-trim.ts
@@ -12,7 +12,7 @@ type VariationItem = NonNullable<
 
 const trimVariationItem = (
     item: VariationItem,
-    onChanged: () => void
+    onChanged: () => void,
 ): VariationItem => {
     const trimmedLabel = item.label.trim();
     if (trimmedLabel !== item.label) {
@@ -42,7 +42,7 @@ const trimVariationItem = (
 
 const trimFormTypeVariation = (
     variation: FormTypeVariation,
-    onChanged: () => void
+    onChanged: () => void,
 ): FormTypeVariation => {
     const selected = variation._selected;
     const selectedData = (variation as Record<string, unknown>)[selected] as {
@@ -67,7 +67,7 @@ const trimFormTypeVariation = (
 };
 
 export const buildTrimmedFormDetailsData = (
-    data: FormDetails
+    data: FormDetails,
 ): { trimmedData: FormDetails; hasChanges: boolean } => {
     let hasChanges = false;
     const onChanged = () => {

--- a/src/main/resources/lib/contentUpdate/form-details-trim.ts
+++ b/src/main/resources/lib/contentUpdate/form-details-trim.ts
@@ -1,5 +1,4 @@
 import * as contentLib from '/lib/xp/content';
-import { Content } from '/lib/xp/content';
 import { FormDetails } from '@xp-types/site/content-types/form-details';
 import { forceArray } from '../utils/array-utils';
 import { logger } from '../utils/logging';
@@ -116,7 +115,7 @@ export const buildTrimmedFormDetailsData = (
     return { trimmedData, hasChanges };
 };
 
-export const trimFormDetailsWhitespace = (content: Content<'no.nav.navno:form-details'>) => {
+export const trimFormDetailsWhitespace = (content: contentLib.Content<'no.nav.navno:form-details'>) => {
     const { trimmedData, hasChanges } = buildTrimmedFormDetailsData(content.data);
 
     if (!hasChanges) {

--- a/test/unit-tests/tests/lib/contentUpdate/form-details-trim.test.ts
+++ b/test/unit-tests/tests/lib/contentUpdate/form-details-trim.test.ts
@@ -1,0 +1,239 @@
+import { buildTrimmedFormDetailsData } from '@navno-app/lib/contentUpdate/form-details-trim';
+import { FormDetails } from '@xp-types/site/content-types/form-details';
+
+const baseData: FormDetails = {
+    title: 'Tittel',
+    audience: {
+        _selected: ['person'],
+        person: {},
+        employer: {},
+        provider: { provider_audience: 'doctor' },
+        other: {},
+    },
+    formType: [],
+};
+
+const makeExternalVariation = (label: string, url: string, formNumber?: string) => ({
+    label,
+    link: {
+        _selected: 'external' as const,
+        external: { url, formNumber },
+    },
+});
+
+const makeInternalVariation = (label: string, target: string) => ({
+    label,
+    link: {
+        _selected: 'internal' as const,
+        internal: { target },
+    },
+});
+
+describe('buildTrimmedFormDetailsData', () => {
+    describe('Top-level text fields', () => {
+        test('trims leading and trailing whitespace from title', () => {
+            const { trimmedData, hasChanges } = buildTrimmedFormDetailsData({
+                ...baseData,
+                title: '  Tittel  ',
+            });
+            expect(trimmedData.title).toBe('Tittel');
+            expect(hasChanges).toBe(true);
+        });
+
+        test('trims longTitle when present', () => {
+            const { trimmedData, hasChanges } = buildTrimmedFormDetailsData({
+                ...baseData,
+                longTitle: ' Lang tittel ',
+            });
+            expect(trimmedData.longTitle).toBe('Lang tittel');
+            expect(hasChanges).toBe(true);
+        });
+
+        test('leaves longTitle undefined when not set', () => {
+            const { trimmedData, hasChanges } = buildTrimmedFormDetailsData(baseData);
+            expect(trimmedData.longTitle).toBeUndefined();
+            expect(hasChanges).toBe(false);
+        });
+
+        test('trims languageDisclaimer', () => {
+            const { trimmedData, hasChanges } = buildTrimmedFormDetailsData({
+                ...baseData,
+                languageDisclaimer: '\tTekst om språk\n',
+            });
+            expect(trimmedData.languageDisclaimer).toBe('Tekst om språk');
+            expect(hasChanges).toBe(true);
+        });
+
+        test('trims each formNumber in the array', () => {
+            const { trimmedData, hasChanges } = buildTrimmedFormDetailsData({
+                ...baseData,
+                formNumbers: [' NAV 01-01.00 ', ' NAV 02-02.00'],
+            });
+            expect(trimmedData.formNumbers).toEqual(['NAV 01-01.00', 'NAV 02-02.00']);
+            expect(hasChanges).toBe(true);
+        });
+
+        test('trims a single formNumber string', () => {
+            const { trimmedData, hasChanges } = buildTrimmedFormDetailsData({
+                ...baseData,
+                formNumbers: ' NAV 01-01.00 ',
+            });
+            expect(trimmedData.formNumbers).toBe('NAV 01-01.00');
+            expect(hasChanges).toBe(true);
+        });
+
+        test('returns undefined formNumbers when not set', () => {
+            const { trimmedData } = buildTrimmedFormDetailsData(baseData);
+            expect(trimmedData.formNumbers).toBeUndefined();
+        });
+    });
+
+    describe('Variation labels and external links', () => {
+        test('trims label in application variation', () => {
+            const { trimmedData, hasChanges } = buildTrimmedFormDetailsData({
+                ...baseData,
+                formType: [
+                    {
+                        _selected: 'application',
+                        application: {
+                            variations: [makeExternalVariation(' Søk digitalt ', 'https://nav.no')],
+                        },
+                    },
+                ],
+            });
+
+            const ft = trimmedData.formType[0] as Extract<
+                FormDetails['formType'][number],
+                { _selected: 'application' }
+            >;
+            expect(ft.application.variations![0].label).toBe('Søk digitalt');
+            expect(hasChanges).toBe(true);
+        });
+
+        test('trims external url in variation link', () => {
+            const { trimmedData, hasChanges } = buildTrimmedFormDetailsData({
+                ...baseData,
+                formType: [
+                    {
+                        _selected: 'complaint',
+                        complaint: {
+                            variations: [
+                                {
+                                    ...makeExternalVariation('Klage', ' https://nav.no/klage '),
+                                    type: 'complaint',
+                                },
+                            ],
+                        },
+                    },
+                ],
+            });
+
+            const ft = trimmedData.formType[0] as Extract<
+                FormDetails['formType'][number],
+                { _selected: 'complaint' }
+            >;
+            type ComplaintVariation = NonNullable<typeof ft.complaint.variations>[number];
+            const link = ft.complaint.variations![0].link as Extract<
+                ComplaintVariation['link'],
+                { _selected: 'external' }
+            >;
+            expect(link.external.url).toBe('https://nav.no/klage');
+            expect(hasChanges).toBe(true);
+        });
+
+        test('trims formNumber in external link', () => {
+            const { trimmedData, hasChanges } = buildTrimmedFormDetailsData({
+                ...baseData,
+                formType: [
+                    {
+                        _selected: 'addendum',
+                        addendum: {
+                            variations: [
+                                makeExternalVariation('Ettersend', 'https://nav.no', ' NAV 10-10.00 '),
+                            ],
+                        },
+                    },
+                ],
+            });
+
+            const ft = trimmedData.formType[0] as Extract<
+                FormDetails['formType'][number],
+                { _selected: 'addendum' }
+            >;
+            type AddendumVariation = NonNullable<typeof ft.addendum.variations>[number];
+            const link = ft.addendum.variations![0].link as Extract<
+                AddendumVariation['link'],
+                { _selected: 'external' }
+            >;
+            expect(link.external.formNumber).toBe('NAV 10-10.00');
+            expect(hasChanges).toBe(true);
+        });
+
+        test('does not touch internal link target', () => {
+            const target = 'abc-123';
+            const { trimmedData, hasChanges } = buildTrimmedFormDetailsData({
+                ...baseData,
+                formType: [
+                    {
+                        _selected: 'application',
+                        application: {
+                            variations: [makeInternalVariation('Send inn', target)],
+                        },
+                    },
+                ],
+            });
+
+            const ft = trimmedData.formType[0] as Extract<
+                FormDetails['formType'][number],
+                { _selected: 'application' }
+            >;
+            type ApplicationVariation = NonNullable<typeof ft.application.variations>[number];
+            const link = ft.application.variations![0].link as Extract<
+                ApplicationVariation['link'],
+                { _selected: 'internal' }
+            >;
+            expect(link.internal.target).toBe(target);
+            expect(hasChanges).toBe(false);
+        });
+
+        test('handles variations being undefined', () => {
+            const { trimmedData, hasChanges } = buildTrimmedFormDetailsData({
+                ...baseData,
+                formType: [
+                    {
+                        _selected: 'application',
+                        application: {},
+                    },
+                ],
+            });
+
+            const ft = trimmedData.formType[0] as Extract<
+                FormDetails['formType'][number],
+                { _selected: 'application' }
+            >;
+            expect(ft.application.variations).toBeUndefined();
+            expect(hasChanges).toBe(false);
+        });
+    });
+
+    describe('No-op when already trimmed', () => {
+        test('reports no changes when all fields are already trimmed', () => {
+            const { hasChanges } = buildTrimmedFormDetailsData({
+                ...baseData,
+                title: 'Allerede trimmet',
+                longTitle: 'Lang tittel',
+                formNumbers: ['NAV 01-01.00'],
+                formType: [
+                    {
+                        _selected: 'application',
+                        application: {
+                            variations: [makeExternalVariation('Søk', 'https://nav.no')],
+                        },
+                    },
+                ],
+            });
+
+            expect(hasChanges).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
https://github.com/navikt/nav-enonicxp/issues/2466

TL;DR:
Legger til automatisk fjerning av ledende og etterfølgende mellomrom i tekstfelt på `formDetails`-innholdstypen når en redaktør lagrer i Content Studio.

Berørte felt:
- Tittel, tittel for søk, informasjon om språk, skjemanummer
- Knappetekst, skjemanummer og URL i variasjoner (søknad, klage/anke, ettersendelse)

Trimming skjer via en node.updated-lytter som allerede finnes i applikasjonen. For å unngå uendelig løkke gjøres `contentLib.modify `kun kalt dersom minst ett felt faktisk hadde overflødig whitespace.

---

**Endringer**
Ny fil src/main/resources/lib/contentUpdate/form-details-trim.ts
- `buildTrimmedFormDetailsData` — ren funksjon som returnerer trimmede data + `hasChanges`-flagg
- `trimFormDetailsWhitespace` — kaller `contentLib.modify `kun når noe faktisk endres (loop-guard mot uendelig event-syklus)

Felt som trimmes:
- title, longTitle, languageDisclaimer, formNumbers[]
- I hvert `formType`-variasjonsitem: label, link.external.formNumber, link.external.url

Endret src/main/resources/lib/contentUpdate/content-update-listener.ts
- Nytt case 'no.nav.navno:form-details' i den eksisterende `handleUpdateEvent` (node.updated-lytteren)
- Filtrerer på `branch === 'draft'` slik at trimming kun skjer ved lagring, ikke ved publisering

---

**I praksis:**
   1. Redaktør klikker «Lagre» → Enonic XP skriver til draft-branchen og sender et node.updated-event.
   2. handleUpdateEvent i content-update-listener.ts plukker opp eventet → henter innholdet med contentLib.get og treffer case 'no.nav.navno:form-details'.
   3. trimFormDetailsWhitespace kalles → beregner trimmede verdier for alle tekstfelt og sjekker om noe faktisk endret seg (hasChanges).
   4. To mulige utfall:
   - Ingen endring (alt var allerede trimmet) → funksjonen returnerer uten å gjøre noe. Ingen ny skriving, ingen ny event.
   - Noe hadde mellomrom → contentLib.modify kalles og skriver trimmede verdier tilbake til innholdet. Dette trigger et nytt node.updated-event, men da er alt
  allerede trimmet, så steg 4 ender med «ingen endring» og stopper.

  Resultatet er at redaktøren aldri trenger å tenke på mellomrom — de trimmes automatisk i bakgrunnen etter lagring.