### PR TITLE
Redirect fra Redirects-mappen respekterer nå valgt språkversjon

### DIFF
--- a/src/main/resources/services/sitecontent/public/not-found-redirects.ts
+++ b/src/main/resources/services/sitecontent/public/not-found-redirects.ts
@@ -140,7 +140,7 @@ export const sitecontentNotFoundRedirect = ({
             ? runInLocaleContext(
                   {
                       locale:
-                          getContentLocaleRedirectTarget(redirectContent) ??
+                          getContentLocaleRedirectTarget(redirectContent) ||
                           redirectContent.language,
                   },
                   () => runSitecontentGuillotineQuery(redirectContent, branch)

--- a/src/main/resources/services/sitecontent/public/not-found-redirects.ts
+++ b/src/main/resources/services/sitecontent/public/not-found-redirects.ts
@@ -8,6 +8,7 @@ import { runInLocaleContext } from '../../../lib/localization/locale-context';
 import { runSitecontentGuillotineQuery } from '../../../lib/guillotine/queries/run-sitecontent-query';
 import { transformToRedirect } from '../common/transform-to-redirect';
 import { SitecontentResponse } from '../common/content-response';
+import { getContentLocaleRedirectTarget } from '../../../lib/utils/content-utils';
 
 const MAX_PARENT_PATH_LENGTH = 10;
 
@@ -136,8 +137,13 @@ export const sitecontentNotFoundRedirect = ({
             getRedirectFromAncestors(`${REDIRECTS_ROOT_PATH}${strippedPath}`);
 
         return redirectContent
-            ? runInLocaleContext({ locale: redirectContent.language }, () =>
-                  runSitecontentGuillotineQuery(redirectContent, branch)
+            ? runInLocaleContext(
+                  {
+                      locale:
+                          getContentLocaleRedirectTarget(redirectContent) ??
+                          redirectContent.language,
+                  },
+                  () => runSitecontentGuillotineQuery(redirectContent, branch)
               )
             : null;
     });


### PR DESCRIPTION
https://github.com/navikt/nav-enonicxp-frontend/issues/2477

Redirect fra Redirects-mappen respekterer nå valgt språkversjon

**Endring**
src/main/resources/services/sitecontent/public/not-found-redirects.ts
- Importerer getContentLocaleRedirectTarget fra content-utils
- Bruker `getContentLocaleRedirectTarget(redirectContent) ?? redirectContent.language` som `locale` i `runInLocaleContext`

**Bruk**
Redaktøren setter «Redirect til språkversjon» (`redirectToLayer.locale`) på den interne lenken i Redirects-mappen til f.eks. `en`. Da kjøres guillotine-queryen i engelsk kontekst, og `contentLib.get({ key: targetId })` returnerer den engelske versjonen av målinnholdet.
Uten en redirect faller koden tilbake til `redirectContent.language` — eksisterende oppførsel er uendret.

Janne har testet i dev.