### PR TITLE
Fikser kontor import

### DIFF
--- a/src/main/resources/lib/guillotine/queries/run-sitecontent-query.ts
+++ b/src/main/resources/lib/guillotine/queries/run-sitecontent-query.ts
@@ -19,6 +19,7 @@ import { getLocaleFromContext } from '../../localization/locale-context';
 import { isContentPreviewOnly } from '../../utils/content-utils';
 import { SitecontentResponse } from '../../../services/sitecontent/common/content-response';
 import { ContentDescriptor } from '../../../types/content-types/content-config';
+import { OfficeTypes } from 'lib/office-pages/types';
 
 export type GuillotineUnresolvedComponentType = { type: ComponentType; path: string };
 
@@ -57,8 +58,8 @@ export const runSitecontentGuillotineQuery = (
     // we need to run buildOfficeBranchPageWithEditorialContent that will specifically look for and resolve the editorial page.
     if (
         baseContent.type === 'no.nav.navno:office-page' &&
-        (baseContent.data?.officeNorgData.data.type === 'LOKAL' ||
-            baseContent.data?.officeNorgData.data.type === 'ALS')
+        (baseContent.data?.officeNorgData.data.type === OfficeTypes.LOKAL ||
+            baseContent.data?.officeNorgData.data.type === OfficeTypes.ALS)
     ) {
         return buildOfficeBranchPageWithEditorialContent(contentQueryResult);
     }

--- a/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/office-callback.ts
+++ b/src/main/resources/lib/guillotine/schema/schema-creation-callbacks/office-callback.ts
@@ -3,6 +3,7 @@ import * as contentLib from '/lib/xp/content';
 import { CreationCallback } from '../../utils/creation-callback-utils';
 import { logger } from '../../../utils/logging';
 import { CONTENT_LOCALE_DEFAULT } from '../../../constants';
+import { OfficeTypes } from '../../../office-pages/types';
 
 export const officeCallback: CreationCallback = (context, params) => {
     params.fields.editorial = {
@@ -29,7 +30,7 @@ export const officeCallback: CreationCallback = (context, params) => {
                 return null;
             }
 
-            if (officeData.type !== 'LOKAL' && officeData.type !== 'ALS') {
+            if (officeData.type !== OfficeTypes.LOKAL && officeData.type !== OfficeTypes.ALS) {
                 return null;
             }
 
@@ -39,7 +40,7 @@ export const officeCallback: CreationCallback = (context, params) => {
             // before checking.
             const language = skriftspraak?.toUpperCase() === 'NN' ? 'nn' : CONTENT_LOCALE_DEFAULT;
 
-            const rootFolder = officeData.type === 'ALS' ? 'arbeidsgiver' : 'kontor';
+            const rootFolder = officeData.type === OfficeTypes.ALS ? 'arbeidsgiver' : 'kontor';
 
             const queryResult = contentLib.query({
                 contentTypes: ['no.nav.navno:office-editorial-page'],

--- a/src/main/resources/lib/office-pages/office-tasks.ts
+++ b/src/main/resources/lib/office-pages/office-tasks.ts
@@ -5,7 +5,7 @@ import { processAllOffices, fetchAllOfficeDataFromNorg } from './office-update';
 import { runInContext } from '../context/run-in-context';
 
 const OFFICE_FETCH_TASK_NAME = 'no.nav.navno:update-office';
-const CRON_SCHEDULE = app.config.env === 'localhost' ? '* * * * *' : '* * * * *';
+const CRON_SCHEDULE = app.config.env === 'localhost' ? '*/10 * * * *' : '* * * * *';
 
 const MAX_FAILURE_COUNT_BEFORE_CRITICAL = 10;
 

--- a/src/main/resources/lib/office-pages/office-tasks.ts
+++ b/src/main/resources/lib/office-pages/office-tasks.ts
@@ -5,7 +5,7 @@ import { processAllOffices, fetchAllOfficeDataFromNorg } from './office-update';
 import { runInContext } from '../context/run-in-context';
 
 const OFFICE_FETCH_TASK_NAME = 'no.nav.navno:update-office';
-const CRON_SCHEDULE = app.config.env === 'localhost' ? '*/10 * * * *' : '* * * * *';
+const CRON_SCHEDULE = app.config.env === 'localhost' ? '* * * * *' : '* * * * *';
 
 const MAX_FAILURE_COUNT_BEFORE_CRITICAL = 10;
 

--- a/src/main/resources/lib/office-pages/office-update.ts
+++ b/src/main/resources/lib/office-pages/office-update.ts
@@ -16,6 +16,7 @@ import {
 } from '../constants';
 import { createObjectChecksum } from '../utils/object-utils';
 import { OfficeRawNORGData } from './office-raw-norg-data';
+import { OfficeTypes } from './types';
 
 type OfficePageDescriptor = NavNoDescriptor<'office-page'>;
 type InternalLinkDescriptor = NavNoDescriptor<'internal-link'>;
@@ -37,7 +38,7 @@ const officeNameOverrides: Readonly<Record<string, string>> = {
     '0891': 'Nav arbeidslivssenter Vestfold og Telemark',
 };
 
-const officeTypesToForcePublish = new Set(['LOKAL']);
+const officeTypesToForcePublish = new Set([OfficeTypes.LOKAL]);
 
 const OFFICE_PAGE_CONTENT_TYPE: OfficePageDescriptor = `no.nav.navno:office-page`;
 const INTERNAL_LINK_CONTENT_TYPE: InternalLinkDescriptor = `no.nav.navno:internal-link`;
@@ -45,10 +46,10 @@ const OFFICES_BASE_PATH = '/www.nav.no/kontor';
 const ALS_OFFICES_BASE_PATH = '/www.nav.no/arbeidsgiver';
 
 const getOfficeContentName = (officeData: OfficeNorgData) => commonLib.sanitize(officeData.navn);
-const officeTypesForImport: ReadonlySet<string> = new Set(['HMS', 'ALS']);
+const officeTypesForImport: ReadonlySet<string> = new Set([OfficeTypes.HMS, OfficeTypes.ALS]);
 
 const getParentPathForType = (type: string) =>
-    type === 'ALS' ? ALS_OFFICES_BASE_PATH : OFFICES_BASE_PATH;
+    type === OfficeTypes.ALS ? ALS_OFFICES_BASE_PATH : OFFICES_BASE_PATH;
 
 const norgRequest = <T>(requestConfig: HttpRequestParams): T[] | null => {
     const response = request({
@@ -71,23 +72,23 @@ const norgRequest = <T>(requestConfig: HttpRequestParams): T[] | null => {
     }
 };
 
-const createForcedWorkflowState = (
-    state: Workflow['state'],
-    existingOfficePage: Content<OfficePageDescriptor>
-) => {
-    if (existingOfficePage.data.officeNorgData?.data?.type !== 'LOKAL') {
+const forceReadyStateIfLocal = (existingOfficePage: Content<OfficePageDescriptor>) => {
+    if (existingOfficePage.data.officeNorgData?.data?.type !== OfficeTypes.LOKAL) {
         return null;
     }
     // If the updatable office is LOKAL (lokalkontor), we want to force publish it.
     // setting state: 'READY' is the first step to allow this.
     return {
         workflow: {
-            state,
+            state: 'READY' as Workflow['state'],
         },
     };
 };
 
-const localOfficeAdapter = (officeData: OfficeRawNORGData) => ({ ...officeData, type: 'LOKAL' });
+const localOfficeAdapter = (officeData: OfficeRawNORGData) => ({
+    ...officeData,
+    type: OfficeTypes.LOKAL,
+});
 
 const generalOfficeAdapter = (
     officeData: OfficeRawNORGData,
@@ -342,7 +343,7 @@ const updateOfficePageIfChanged = (
                     officeData: newOfficeData,
                     checksum: newChecksum,
                 }),
-                ...createForcedWorkflowState('READY', existingOfficePage), // Forces LOKAL to be ready for publish
+                ...forceReadyStateIfLocal(existingOfficePage),
             }),
             requireValid: false,
         });
@@ -351,7 +352,7 @@ const updateOfficePageIfChanged = (
         // editor might also be working on a draft. LOKAL (lokalkontor) however
         // should always be published immediately.
         const shouldPublish =
-            officeTypesToForcePublish.has(newOfficeData.type) ||
+            officeTypesToForcePublish.has(newOfficeData.type as OfficeTypes) ||
             (isUpToDateWithMaster && allOutboundsArePublished);
 
         return shouldPublish;
@@ -370,7 +371,7 @@ const createOfficePage = (officeData: OfficeNorgData) => {
         checksum: createObjectChecksum(officeData),
     });
 
-    const previewOnly = officeData.type !== 'LOKAL';
+    const previewOnly = officeData.type !== OfficeTypes.LOKAL;
 
     try {
         const content = contentLib.create({

--- a/src/main/resources/lib/office-pages/office-update.ts
+++ b/src/main/resources/lib/office-pages/office-update.ts
@@ -36,6 +36,8 @@ const officeNameOverrides: Readonly<Record<string, string>> = {
     '0891': 'Nav arbeidslivssenter Vestfold og Telemark',
 };
 
+const officeTypesToForcePublish = new Set(['LOKAL']);
+
 const OFFICE_PAGE_CONTENT_TYPE: OfficePageDescriptor = `no.nav.navno:office-page`;
 const INTERNAL_LINK_CONTENT_TYPE: InternalLinkDescriptor = `no.nav.navno:internal-link`;
 const OFFICES_BASE_PATH = '/www.nav.no/kontor';
@@ -327,14 +329,14 @@ const updateOfficePageIfChanged = (
             requireValid: false,
         });
 
-        // Content can only be published if it and it's outbound content
-        // is udate with master. Ie, content that currently is in
-        // some sort of "in progress" by editors, should not
-        // be automatically published.
-        logger.info(
-            `OfficeImporting: Updated office page ${existingOfficePage._path}. Up to date with master: ${isUpToDateWithMaster}, all outbound dependencies are published: ${allOutboundsArePublished}`
-        );
-        return isUpToDateWithMaster && allOutboundsArePublished;
+        // Some office types have an editorial part, and should not be force published as an
+        // editor might also be working on a draft. LOKAL (lokalkontor) however
+        // should always be published immediately.
+        const shouldPublish =
+            officeTypesToForcePublish.has(newOfficeData.type) ||
+            (isUpToDateWithMaster && allOutboundsArePublished);
+
+        return shouldPublish;
     } catch (e) {
         logger.critical(
             `OfficeImporting: Failed to modify office page content ${existingOfficePage._path} - ${e}`
@@ -426,9 +428,7 @@ export const processAllOffices = (offices: OfficeNorgData[]) => {
 
         if (existingOffice) {
             const shouldBePublished = updateOfficePageIfChanged(officePageData, existingOffice);
-            logger.info(
-                `OfficeImporting: ${officePageData.navn} already exists, updating content. Should be published: ${shouldBePublished}`
-            );
+
             if (shouldBePublished) {
                 summary.updated.push(existingOffice._id);
             }

--- a/src/main/resources/lib/office-pages/office-update.ts
+++ b/src/main/resources/lib/office-pages/office-update.ts
@@ -331,6 +331,9 @@ const updateOfficePageIfChanged = (
         // is udate with master. Ie, content that currently is in
         // some sort of "in progress" by editors, should not
         // be automatically published.
+        logger.info(
+            `OfficeImporting: Updated office page ${existingOfficePage._path}. Up to date with master: ${isUpToDateWithMaster}, all outbound dependencies are published: ${allOutboundsArePublished}`
+        );
         return isUpToDateWithMaster && allOutboundsArePublished;
     } catch (e) {
         logger.critical(
@@ -423,6 +426,9 @@ export const processAllOffices = (offices: OfficeNorgData[]) => {
 
         if (existingOffice) {
             const shouldBePublished = updateOfficePageIfChanged(officePageData, existingOffice);
+            logger.info(
+                `OfficeImporting: ${officePageData.navn} already exists, updating content. Should be published: ${shouldBePublished}`
+            );
             if (shouldBePublished) {
                 summary.updated.push(existingOffice._id);
             }

--- a/src/main/resources/lib/office-pages/office-update.ts
+++ b/src/main/resources/lib/office-pages/office-update.ts
@@ -1,6 +1,7 @@
 import * as contentLib from '/lib/xp/content';
 import { Content } from '/lib/xp/content';
 import { HttpRequestParams, request } from '/lib/http-client';
+import { Workflow } from '@enonic-types/core';
 import * as commonLib from '/lib/xp/common';
 import { isDraftAndMasterSameVersion } from '../repos/repo-utils';
 import { OfficePage as OfficePageData } from '@xp-types/site/content-types/office-page';
@@ -68,6 +69,22 @@ const norgRequest = <T>(requestConfig: HttpRequestParams): T[] | null => {
         );
         return null;
     }
+};
+
+const createForcedWorkflowState = (
+    state: Workflow['state'],
+    existingOfficePage: Content<OfficePageDescriptor>
+) => {
+    if (existingOfficePage.data.officeNorgData?.data?.type !== 'LOKAL') {
+        return null;
+    }
+    // If the updatable office is LOKAL (lokalkontor), we want to force publish it.
+    // setting state: 'READY' is the first step to allow this.
+    return {
+        workflow: {
+            state,
+        },
+    };
 };
 
 const localOfficeAdapter = (officeData: OfficeRawNORGData) => ({ ...officeData, type: 'LOKAL' });
@@ -325,6 +342,7 @@ const updateOfficePageIfChanged = (
                     officeData: newOfficeData,
                     checksum: newChecksum,
                 }),
+                ...createForcedWorkflowState('READY', existingOfficePage), // Forces LOKAL to be ready for publish
             }),
             requireValid: false,
         });

--- a/src/main/resources/lib/office-pages/types.ts
+++ b/src/main/resources/lib/office-pages/types.ts
@@ -11,6 +11,12 @@ const OFFICE_PAGE_TYPES = [
     'no.nav.navno:office-page',
 ] as const satisfies ReadonlyArray<ContentDescriptor>;
 
+export enum OfficeTypes {
+    LOKAL = 'LOKAL',
+    HMS = 'HMS',
+    ALS = 'ALS',
+}
+
 export const isOfficeContent = (content: Content): content is OfficeContent =>
     OFFICE_PAGE_TYPES.includes((content as OfficeContent).type);
 

--- a/src/main/resources/lib/search/document-builder/document-builder.ts
+++ b/src/main/resources/lib/search/document-builder/document-builder.ts
@@ -27,7 +27,7 @@ import {
     getSearchDocumentLanguage,
     getSearchDocumentLanguageRefs,
 } from './field-resolvers/language';
-import { isOfficeContent } from '../../office-pages/types';
+import { isOfficeContent, OfficeTypes } from '../../office-pages/types';
 import {
     buildSearchDocumentIngress,
     buildSearchDocumentOfficeIngress,
@@ -228,7 +228,7 @@ const isExcludedContent = (content: ContentNode) => {
     switch (content.type) {
         // 'LOKAL' office type is handled by the new office-page content type
         case 'no.nav.navno:office-information': {
-            return content.data.enhet.type === 'LOKAL';
+            return content.data.enhet.type === OfficeTypes.LOKAL;
         }
         // Only form details which contain an application should be indexed
         case 'no.nav.navno:form-details': {

--- a/src/main/resources/lib/search/document-builder/field-resolvers/ingress.ts
+++ b/src/main/resources/lib/search/document-builder/field-resolvers/ingress.ts
@@ -2,6 +2,7 @@ import { logger } from '../../../utils/logging';
 import { OfficeContent, Publikumsmottak } from '../../../office-pages/types';
 import { forceArray, removeDuplicatesFilter } from '../../../utils/array-utils';
 import { capitalize } from '../../../utils/string-utils';
+import { OfficeTypes } from '../../../office-pages/types';
 
 const INGRESS_MAX_LENGTH = 500;
 
@@ -46,7 +47,7 @@ export const buildSearchDocumentOfficeIngress = (content: OfficeContent) => {
         return '';
     }
 
-    if (officeData.type === 'HMS' || officeData.type === 'ALS') {
+    if (officeData.type === OfficeTypes.HMS || officeData.type === OfficeTypes.ALS) {
         return content.data.metaDescription || officeData.navn;
     }
 

--- a/src/main/resources/lib/search/document-builder/field-resolvers/ingress.ts
+++ b/src/main/resources/lib/search/document-builder/field-resolvers/ingress.ts
@@ -1,8 +1,7 @@
 import { logger } from '../../../utils/logging';
-import { OfficeContent, Publikumsmottak } from '../../../office-pages/types';
+import { OfficeContent, Publikumsmottak, OfficeTypes } from '../../../office-pages/types';
 import { forceArray, removeDuplicatesFilter } from '../../../utils/array-utils';
 import { capitalize } from '../../../utils/string-utils';
-import { OfficeTypes } from '../../../office-pages/types';
 
 const INGRESS_MAX_LENGTH = 500;
 


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Setter workflow.state til 'READY' og tvinger publisering av lokalkontor.
Endrer referanser til kontortype slik at den bruker enums.

## Testing
Testet i dev. Også testet at hjelpemiddelsentral og arbeidslivssenter ikke berøres