### PR TITLE
Normalisere lenke til forsiden på 'no'

### DIFF
--- a/src/main/resources/services/menu/menu.ts
+++ b/src/main/resources/services/menu/menu.ts
@@ -40,9 +40,13 @@ const getTargetPath = (menuItem: MenuItemContent, locale: string) => {
 
     if (target.type === 'no.nav.navno:external-link') {
         return target.data.url;
-    } else {
-        return getPublicPath(target, locale);
     }
+
+    if (target._path === '/www.nav.no/no') {
+        return '/';
+    }
+
+    return getPublicPath(target, locale);
 };
 
 const menuItemContentTransformer = (menuItem: MenuItemContent, locale: string): MenuItem => {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Lenke til forsiden ender opp med /no/en fordi tilsvarende side er lokalisert, så 'en' slenges på. Legger inn et unntak.

## Testing
Testet i dev