### PR TITLE
Sjekker om innhold faktisk har components før henting av template

### DIFF
--- a/src/main/resources/lib/external-archive/get-archived-content.ts
+++ b/src/main/resources/lib/external-archive/get-archived-content.ts
@@ -12,7 +12,8 @@ import { Content } from '/lib/xp/content';
 import { forceArray } from '../utils/array-utils';
 
 const pageHasComponents = (content: NonNullable<SitecontentResponse>) => {
-    return content.page?.regions?.pageContent?.components?.length > 0;
+    const components = forceArray(content.page?.regions?.pageContent?.components);
+    return components.length > 0;
 };
 
 // We need to find page templates ourselves, as the version history hack we use for resolving content

--- a/src/main/resources/lib/external-archive/get-archived-content.ts
+++ b/src/main/resources/lib/external-archive/get-archived-content.ts
@@ -11,11 +11,15 @@ import { SitecontentResponse } from '../../services/sitecontent/common/content-r
 import { Content } from '/lib/xp/content';
 import { forceArray } from '../utils/array-utils';
 
+const pageHasComponents = (content: NonNullable<SitecontentResponse>) => {
+    return content.page?.regions?.pageContent?.components?.length > 0;
+};
+
 // We need to find page templates ourselves, as the version history hack we use for resolving content
 // from the archive does not work with the Java method Guillotine uses for resolving page templates
 const getPageTemplate = (content: NonNullable<SitecontentResponse>) => {
     // If the content has its own customized page component, it should not need a page template
-    if (content.page?.customized) {
+    if (content.page?.customized || pageHasComponents(content)) {
         return null;
     }
 


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Det har skjedd noe i XP som gjør at customized ikke lenger settes til true når innhold løsrives. Det gjør at visning av arkivert innhold ikke fungerer.

Dette fikser symptomene slik at redaktørene får tilbake visning av arkivert innhold, og så kan vi grave i årsaken i litt mer organiserte former.

## Testing
Testes i dev
